### PR TITLE
Add support for nested folders

### DIFF
--- a/apps/dev/src/pages/api/nested/route.ts
+++ b/apps/dev/src/pages/api/nested/route.ts
@@ -1,0 +1,10 @@
+import { defineEndpoints } from 'next-rest-framework/client';
+
+export default defineEndpoints({
+  GET: {
+    handler: ({ res }) => {
+      res.setHeader('content-type', 'application/json');
+      res.status(200).send('Hello World!');
+    }
+  }
+});

--- a/packages/next-rest-framework/tests/paths.test.ts
+++ b/packages/next-rest-framework/tests/paths.test.ts
@@ -13,13 +13,17 @@ import chalk from 'chalk';
 import { z } from 'zod';
 import * as yup from 'yup';
 
+const createDirent = (name: string) => ({
+  isDirectory: () => name === 'foo',
+  isFile: () => name !== 'foo',
+  name
+});
+
 jest.mock('fs', () => ({
-  readdirSync: () => [
-    'foo.ts',
-    'foo/bar.ts',
-    'foo/bar/baz.ts',
-    'foo/bar/[qux]/index.ts'
-  ]
+  readdirSync: () =>
+    ['foo.ts', 'foo/bar.ts', 'foo/bar/baz.ts', 'foo/bar/[qux]/index.ts'].map(
+      createDirent
+    )
 }));
 
 beforeEach(() => {


### PR DESCRIPTION
This fixes a bug where API routes defined
in nested folders were not instrumented by
the OpenAPI generation.