### PR TITLE
Fix OpenAPI instrumentation for dynamic routes

### DIFF
--- a/apps/dev/src/pages/api/dynamic/[slug]/index.ts
+++ b/apps/dev/src/pages/api/dynamic/[slug]/index.ts
@@ -1,0 +1,20 @@
+import { defineEndpoints } from 'next-rest-framework/client';
+import { z } from 'zod';
+
+export default defineEndpoints({
+  GET: {
+    input: {
+      query: z.object({
+        slug: z.string()
+      })
+    },
+    handler: ({
+      req: {
+        query: { slug }
+      },
+      res
+    }) => {
+      res.status(200).send(`Hello from slug: ${slug}`);
+    }
+  }
+});

--- a/packages/next-rest-framework/src/define-endpoints.ts
+++ b/packages/next-rest-framework/src/define-endpoints.ts
@@ -264,7 +264,7 @@ export const defineEndpoints = <GlobalMiddlewareResponse>({
         };
 
         if (headers['user-agent'] === NEXT_REST_FRAMEWORK_USER_AGENT) {
-          const route = url ?? '';
+          const route = decodeURIComponent(url ?? '');
 
           try {
             const nextRestFrameworkPaths = getPathsFromMethodHandlers({
@@ -310,19 +310,21 @@ ${error}`);
             return;
           }
 
-          const validateBody = await validateSchema?.({
-            schema: bodySchema,
-            obj: body
-          });
+          if (bodySchema) {
+            const validateBody = await validateSchema?.({
+              schema: bodySchema,
+              obj: body
+            });
 
-          if (validateBody) {
-            const { valid, errors } = validateBody;
+            if (validateBody) {
+              const { valid, errors } = validateBody;
 
-            if (!valid) {
-              res
-                .status(400)
-                .json({ message: `Invalid request body: ${errors}` });
-              return;
+              if (!valid) {
+                res
+                  .status(400)
+                  .json({ message: `Invalid request body: ${errors}` });
+                return;
+              }
             }
           }
 

--- a/packages/next-rest-framework/src/types/method-handlers.ts
+++ b/packages/next-rest-framework/src/types/method-handlers.ts
@@ -18,8 +18,8 @@ export interface InputObject<
   BodySchema extends BaseSchemaType = BaseSchemaType,
   QuerySchema extends BaseObjectSchemaType = BaseObjectSchemaType
 > {
-  contentType: BaseContentType;
-  body: BodySchema;
+  contentType?: BaseContentType;
+  body?: BodySchema;
   query?: QuerySchema;
 }
 

--- a/packages/next-rest-framework/src/utils/open-api.ts
+++ b/packages/next-rest-framework/src/utils/open-api.ts
@@ -284,7 +284,7 @@ export const getPathsFromMethodHandlers = ({
 
       let requestBodyContent: Record<string, OpenAPIV3_1.MediaTypeObject> = {};
 
-      if (input) {
+      if (input?.body && input?.contentType) {
         const schema = getJsonSchema({ schema: input.body });
 
         requestBodyContent = {


### PR DESCRIPTION
This fixes the names of dynamic API routes containing route parameters displayed in the Swagger UI. Another change here is that defining the request body and content type is no longer required in the request input object, making it more suitable for any kind of request and GET requests especially.