### PR TITLE
Fix getting started docs

### DIFF
--- a/docs/docs/getting-started.md
+++ b/docs/docs/getting-started.md
@@ -13,7 +13,9 @@ To use Next REST Framework you need to initialize the client somewhere in your N
 
 import { NextRestFramework } from 'next-rest-framework';
 
-export const { defineCatchAllHandler, defineEndpoints } = NextRestFramework();
+export const { defineCatchAllHandler, defineEndpoints } = NextRestFramework({
+  //  apiRoutesPath: "src/pages/api", // Only needed if using the src/ folder.
+});
 ```
 
 The complete API of the initialized client is the following:

--- a/packages/next-rest-framework/README.md
+++ b/packages/next-rest-framework/README.md
@@ -89,7 +89,9 @@ To use Next REST Framework you need to initialize the client somewhere in your N
 
 import { NextRestFramework } from 'next-rest-framework';
 
-export const { defineCatchAllHandler, defineEndpoints } = NextRestFramework();
+export const { defineCatchAllHandler, defineEndpoints } = NextRestFramework({
+  //  apiRoutesPath: "src/pages/api", // Only needed if using the src/ folder.
+});
 ```
 
 The complete API of the initialized client is the following:
@@ -162,9 +164,9 @@ export default defineEndpoints({
       body: z.object({
         name: z.string()
       }),
-      query: {
+      query: z.object({
         page: z.number()
-      }
+      })
     },
     output: [
       {


### PR DESCRIPTION
This fixes the getting started docs which had a typo in the query param schema definition, resulting in an error when following the getting started guide.

This also documents the support for the `src/` folder in the getting started guide.