### PR TITLE
Fix error with middlewares that respond to API requests

### DIFF
--- a/packages/next-rest-framework/src/define-endpoints.ts
+++ b/packages/next-rest-framework/src/define-endpoints.ts
@@ -352,11 +352,19 @@ ${error}`);
           res
         })) as Awaited<GlobalMiddlewareResponse>;
 
+        if (res.writableEnded) {
+          return;
+        }
+
         const routeMiddlewareParams = (await methodHandlers.middleware?.({
           req,
           res,
           params: globalMiddlewareParams
         })) as Awaited<RouteMiddlewareResponse>;
+
+        if (res.writableEnded) {
+          return;
+        }
 
         const methodMiddlewareParams = (await methodHandler.middleware?.({
           req,
@@ -366,6 +374,10 @@ ${error}`);
             ...routeMiddlewareParams
           }
         })) as Awaited<MiddlewareResponse>;
+
+        if (res.writableEnded) {
+          return;
+        }
 
         const params = {
           ...globalMiddlewareParams,
@@ -386,6 +398,11 @@ ${error}`);
             error,
             params
           });
+
+          if (res.writableEnded) {
+            return;
+          }
+
           returnUnexpectedError();
         }
       };


### PR DESCRIPTION
This fixes a bug with middlewares that responded to the API request. Previously the endpoint execution was continued after every middleware and error handler, resulting in an error in the previously mentioned case.

This fixes the issue by checking wheter the request has been ended after proceeding after every middleware and error handler.