### PR TITLE
Fix path finding for windows environments, and add path parameters to Open API Spec

### DIFF
--- a/packages/next-rest-framework/src/types/method-handlers.ts
+++ b/packages/next-rest-framework/src/types/method-handlers.ts
@@ -41,6 +41,7 @@ export interface MethodHandler<
   RouteMiddlewareResponse = unknown,
   MethodMiddlewareResponse = unknown
 > {
+  tags?: string[];
   input?: InputObject<BodySchema, QuerySchema>;
   output?: Output[];
   middleware?: Middleware<

--- a/packages/next-rest-framework/src/utils/open-api.ts
+++ b/packages/next-rest-framework/src/utils/open-api.ts
@@ -172,7 +172,7 @@ const generatePaths = async ({
     .filter(filterApiRoutes)
     .map((file) =>
       `/api/${file}`
-        .replace('/index', '')
+        .replace(/[/\\]index/, '')
         .replace('[', '{')
         .replace(']', '}')
         .replace('.ts', '')

--- a/packages/next-rest-framework/src/utils/open-api.ts
+++ b/packages/next-rest-framework/src/utils/open-api.ts
@@ -319,7 +319,7 @@ export const getPathsFromMethodHandlers = ({
   Object.keys(methodHandlers)
     .filter(isValidMethod)
     .forEach((_method) => {
-      const { openApiSpecOverrides, input, output } = methodHandlers[
+      const { openApiSpecOverrides, tags, input, output } = methodHandlers[
         _method
       ] as MethodHandler;
 
@@ -355,6 +355,7 @@ export const getPathsFromMethodHandlers = ({
       );
 
       const generatedOperationObject: OpenAPIV3_1.OperationObject = {
+        tags,
         requestBody: {
           content: requestBodyContent
         },

--- a/packages/next-rest-framework/src/utils/open-api.ts
+++ b/packages/next-rest-framework/src/utils/open-api.ts
@@ -373,6 +373,18 @@ export const getPathsFromMethodHandlers = ({
         }));
       }
 
+      const pathParameters = route.match(/{([^}]+)}/g);
+      if (pathParameters) {
+        generatedOperationObject.parameters = [
+          ...(generatedOperationObject.parameters ?? []),
+          ...pathParameters.map((param) => ({
+            name: param.replace(/[{}]/g, ''),
+            in: 'path',
+            required: true
+          }))
+        ];
+      }
+
       paths[route] = {
         ...paths[route],
         [method]: merge(generatedOperationObject, openApiSpecOverrides)

--- a/packages/next-rest-framework/src/utils/open-api.ts
+++ b/packages/next-rest-framework/src/utils/open-api.ts
@@ -364,23 +364,23 @@ export const getPathsFromMethodHandlers = ({
         }
       };
 
-      if (input?.query) {
-        generatedOperationObject.parameters = getSchemaKeys({
-          schema: input.query
-        }).map((key) => ({
-          name: key,
-          in: 'query'
+      const pathParameters = route.match(/{([^}]+)}/g);
+      if (pathParameters) {
+        generatedOperationObject.parameters = pathParameters.map((param) => ({
+          name: param.replace(/[{}]/g, ''),
+          in: 'path',
+          required: true
         }));
       }
 
-      const pathParameters = route.match(/{([^}]+)}/g);
-      if (pathParameters) {
+      if (input?.query) {
         generatedOperationObject.parameters = [
           ...(generatedOperationObject.parameters ?? []),
-          ...pathParameters.map((param) => ({
-            name: param.replace(/[{}]/g, ''),
-            in: 'path',
-            required: true
+          ...getSchemaKeys({
+            schema: input.query
+          }).map((key) => ({
+            name: key,
+            in: 'query'
           }))
         ];
       }

--- a/packages/next-rest-framework/src/utils/open-api.ts
+++ b/packages/next-rest-framework/src/utils/open-api.ts
@@ -172,7 +172,8 @@ const generatePaths = async ({
     .filter(filterApiRoutes)
     .map((file) =>
       `/api/${file}`
-        .replace(/[/\\]index/, '')
+        .replace(/\\/g, '/')
+        .replace('/index', '')
         .replace('[', '{')
         .replace(']', '}')
         .replace('.ts', '')

--- a/packages/next-rest-framework/src/utils/schemas.ts
+++ b/packages/next-rest-framework/src/utils/schemas.ts
@@ -17,6 +17,7 @@ import {
   ZodIntersection,
   ZodNullable,
   ZodNumber,
+  ZodOptional,
   ZodRawShape,
   ZodSchema,
   ZodString,
@@ -82,6 +83,10 @@ const isZodIntersection = (
 
 const isZodDate = (schema: ZodTypeAny): schema is ZodDate => {
   return schema._def.typeName === 'ZodDate';
+};
+
+const isZodOptional = (schema: ZodTypeAny): schema is ZodOptional<any> => {
+  return schema._def.typeName === 'ZodOptional';
 };
 
 export const convertZodSchema = (schema: ZodSchema) => {
@@ -154,6 +159,12 @@ export const convertZodSchema = (schema: ZodSchema) => {
           type: 'string',
           format: 'date-time'
         };
+      }
+
+      if (isZodOptional(value)) {
+        jsonSchema[key as keyof typeof jsonSchema] = convertZodSchema(
+          value._def.innerType
+        );
       }
     });
 

--- a/packages/next-rest-framework/src/utils/schemas.ts
+++ b/packages/next-rest-framework/src/utils/schemas.ts
@@ -12,6 +12,7 @@ import {
   AnyZodObject,
   ZodArray,
   ZodBoolean,
+  ZodDate,
   ZodEnum,
   ZodIntersection,
   ZodNullable,
@@ -79,6 +80,10 @@ const isZodIntersection = (
   return schema._def.typeName === 'ZodIntersection';
 };
 
+const isZodDate = (schema: ZodTypeAny): schema is ZodDate => {
+  return schema._def.typeName === 'ZodDate';
+};
+
 export const convertZodSchema = (schema: ZodSchema) => {
   let jsonSchema = {};
 
@@ -142,6 +147,13 @@ export const convertZodSchema = (schema: ZodSchema) => {
         jsonSchema[key as keyof typeof jsonSchema] = convertZodSchema(
           value._def.innerType
         );
+      }
+
+      if (isZodDate(value)) {
+        jsonSchema[key as keyof typeof jsonSchema] = {
+          type: 'string',
+          format: 'date-time'
+        };
       }
     });
 

--- a/packages/next-rest-framework/tests/paths.test.ts
+++ b/packages/next-rest-framework/tests/paths.test.ts
@@ -274,6 +274,13 @@ it('auto-generates the paths from the internal endpoint responses', async () => 
 
   expect(paths['/api/foo/bar/{qux}']).toEqual({
     get: {
+      parameters: [
+        {
+          in: 'path',
+          name: 'qux',
+          required: true
+        }
+      ],
       requestBody: {
         content: {}
       },


### PR DESCRIPTION
Windows uses `\` instead of `/` for path Seperators. This fixes index routes not found on windows files system.

Add path parameters to OpenApi Spec, e.g. `/api/users/{pid}`, the `pid` now shows up in swagger ui

![image](https://github.com/blomqma/next-rest-framework/assets/19656179/77f050b0-2ce0-4334-bf73-862441187b45)
