### PR TITLE
Readme.md fix file path

### DIFF
--- a/packages/next-rest-framework/README.md
+++ b/packages/next-rest-framework/README.md
@@ -154,7 +154,7 @@ The reserved OpenAPI paths are configurable with the [Config options](#config-op
 #### App Router:
 
 ```typescript
-// src/app/api/todos.ts
+// src/app/api/todos/route.ts
 
 import { defineRoute } from 'next-rest-framework/client';
 import { NextResponse } from 'next/server';


### PR DESCRIPTION
Fixes a small readme typo, where an app router file path was not named "route.ts"