### PR TITLE
Fix directory not found error when using App Router

### DIFF
--- a/docs/docs/getting-started.md
+++ b/docs/docs/getting-started.md
@@ -52,7 +52,7 @@ To initialize Next REST Framework you need to export and call the `defineCatchAl
 
 import { defineCatchAllRoute } from 'next-rest-framework/client';
 
-export default defineCatchAllRoute();
+export const GET = defineCatchAllRoute();
 ```
 
 OR:

--- a/packages/next-rest-framework/README.md
+++ b/packages/next-rest-framework/README.md
@@ -127,7 +127,7 @@ To initialize Next REST Framework you need to export and call the `defineCatchAl
 
 import { defineCatchAllRoute } from 'next-rest-framework/client';
 
-export default defineCatchAllRoute();
+export const GET = defineCatchAllRoute();
 ```
 
 OR:

--- a/packages/next-rest-framework/src/utils/config.ts
+++ b/packages/next-rest-framework/src/utils/config.ts
@@ -4,7 +4,6 @@ import { logNextRestFrameworkError } from './logging';
 import { type NextRestFrameworkConfig } from '../types';
 
 export const DEFAULT_CONFIG = {
-  apiRoutesPath: 'pages/api',
   openApiSpecOverrides: {
     openapi: OPEN_API_VERSION,
     info: {

--- a/packages/next-rest-framework/src/utils/open-api.ts
+++ b/packages/next-rest-framework/src/utils/open-api.ts
@@ -187,34 +187,44 @@ const generatePaths = async ({
 
   const appDirPath = 'appDirPath' in config ? config.appDirPath : '';
 
-  const _routes =
-    (appDirPath &&
-      getNestedRoutes(join(process.cwd(), appDirPath ?? ''), '')
-        .filter(filterRoutes)
-        .map((file) =>
-          `${appDirPath.split('/app')[1]}/${file}`
-            .replace('/route.ts', '')
-            .replace(/\\/g, '/')
-            .replace('[', '{')
-            .replace(']', '}')
-        )) ??
-    [];
+  let _routes: string[] = [];
+
+  try {
+    _routes = appDirPath
+      ? getNestedRoutes(join(process.cwd(), appDirPath ?? ''), '')
+          .filter(filterRoutes)
+          .map((file) =>
+            `${appDirPath.split('/app')[1]}/${file}`
+              .replace('/route.ts', '')
+              .replace(/\\/g, '/')
+              .replace('[', '{')
+              .replace(']', '}')
+          )
+      : [];
+  } catch {
+    // No app directory found.
+  }
 
   const apiRoutesPath = 'apiRoutesPath' in config ? config.apiRoutesPath : '';
 
-  const apiRoutes =
-    (apiRoutesPath &&
-      getNestedRoutes(join(process.cwd(), apiRoutesPath ?? ''), '')
-        .filter(filterApiRoutes)
-        .map((file) =>
-          `/api/${file}`
-            .replace('/index', '')
-            .replace(/\\/g, '/')
-            .replace('[', '{')
-            .replace(']', '}')
-            .replace('.ts', '')
-        )) ??
-    [];
+  let apiRoutes: string[] = [];
+
+  try {
+    apiRoutes = apiRoutesPath
+      ? getNestedRoutes(join(process.cwd(), apiRoutesPath ?? ''), '')
+          .filter(filterApiRoutes)
+          .map((file) =>
+            `/api/${file}`
+              .replace('/index', '')
+              .replace(/\\/g, '/')
+              .replace('[', '{')
+              .replace(']', '}')
+              .replace('.ts', '')
+          )
+      : [];
+  } catch {
+    // No API routes directory found.
+  }
 
   const routes = [..._routes, ...apiRoutes];
 

--- a/packages/next-rest-framework/tests/pages-router/paths.test.ts
+++ b/packages/next-rest-framework/tests/pages-router/paths.test.ts
@@ -31,7 +31,7 @@ beforeEach(() => {
 });
 
 const { defineCatchAllApiRoute, defineApiRoute } = NextRestFramework({
-  appDirPath: 'src/pages/api'
+  apiRoutesPath: 'src/pages/api'
 });
 
 const fooMethodHandlers = defineApiRoute({


### PR DESCRIPTION
This fixes an issue where an error occurred on the pages directory not being found when using App Router - this both removes the default config option that sets a default value for the `apiRoutesPath` option, and also gracefully handles the error when either `appDirPath` or `apiRoutesPath` option is enabled but either of those directories are not found.