### PR TITLE
Use light theme as default on example app

### DIFF
--- a/apps/example/src/app/layout.tsx
+++ b/apps/example/src/app/layout.tsx
@@ -7,7 +7,7 @@ export const metadata = {
 
 export default function Layout({ children }: { children: React.ReactNode }) {
   const cookieStore = cookies();
-  const theme = cookieStore.get('theme')?.value ?? 'dark';
+  const theme = cookieStore.get('theme')?.value ?? 'light';
 
   return (
     <html lang="en" data-theme={theme}>


### PR DESCRIPTION
This way it's consistent with the framework's
default theme.