### PR TITLE
Fix request body validation

### DIFF
--- a/apps/example/src/app/api/routes/todos/route.ts
+++ b/apps/example/src/app/api/routes/todos/route.ts
@@ -32,9 +32,6 @@ const handler = defineRoute({
       body: z.object({
         foo: z.string(),
         bar: z.number()
-      }),
-      query: z.object({
-        test: z.string()
       })
     },
     output: [
@@ -43,61 +40,18 @@ const handler = defineRoute({
         contentType: 'application/json',
         schema: z.object({
           foo: z.string(),
-          bar: z.number(),
-          query: z.object({
-            test: z.string()
-          })
+          bar: z.number()
         })
       }
     ],
-    handler: async (req, { params: { test } }) => {
+    handler: async (req) => {
       const { foo, bar } = await req.json();
 
       return NextResponse.json(
-        { foo, bar, query: { test } },
         {
-          status: 201
-        }
-      );
-    }
-  },
-  PUT: {
-    input: {
-      contentType: 'application/json',
-      body: z.object({
-        foo: z.array(
-          z.object({
-            bar: z.string()
-          })
-        ),
-        baz: z.number()
-      }),
-      query: z.object({
-        test: z.string()
-      })
-    },
-    output: [
-      {
-        status: 201,
-        contentType: 'application/json',
-        schema: z.object({
-          foo: z.array(
-            z.object({
-              bar: z.string()
-            })
-          ),
-          bar: z.number(),
-          query: z.object({
-            test: z.string()
-          })
-        })
-      }
-    ],
-    handler: async (req, { params: { test } }) => {
-      const { foo } = await req.json();
-
-      return NextResponse.json(
-        { foo, bar: 0, query: { test } },
+          foo,
+          bar
+        },
         {
           status: 201
         }

--- a/apps/example/src/pages/api/api-routes/todos.ts
+++ b/apps/example/src/pages/api/api-routes/todos.ts
@@ -25,9 +25,6 @@ export default defineApiRoute({
       body: z.object({
         foo: z.string(),
         bar: z.number()
-      }),
-      query: z.object({
-        test: z.string()
       })
     },
     output: [
@@ -36,51 +33,12 @@ export default defineApiRoute({
         contentType: 'application/json',
         schema: z.object({
           foo: z.string(),
-          bar: z.number(),
-          query: z.object({
-            test: z.string()
-          })
+          bar: z.number()
         })
       }
     ],
-    handler: ({ body: { foo, bar }, query: { test } }, res) => {
-      res.status(201).json({ foo, bar, query: { test } });
-    }
-  },
-  PUT: {
-    input: {
-      contentType: 'application/json',
-      body: z.object({
-        foo: z.array(
-          z.object({
-            bar: z.string()
-          })
-        ),
-        baz: z.number()
-      }),
-      query: z.object({
-        test: z.string()
-      })
-    },
-    output: [
-      {
-        status: 201,
-        contentType: 'application/json',
-        schema: z.object({
-          foo: z.array(
-            z.object({
-              bar: z.string()
-            })
-          ),
-          bar: z.number(),
-          query: z.object({
-            test: z.string()
-          })
-        })
-      }
-    ],
-    handler: ({ body: { foo }, query: { test } }, res) => {
-      res.status(201).json({ foo, bar: 0, query: { test } });
+    handler: ({ body: { foo, bar } }, res) => {
+      res.status(201).json({ foo, bar });
     }
   }
 });

--- a/docs/docs/getting-started.md
+++ b/docs/docs/getting-started.md
@@ -118,9 +118,6 @@ const handler = defineRoute({
       body: z.object({
         foo: z.string(),
         bar: z.number()
-      }),
-      query: z.object({
-        test: z.string()
       })
     },
     output: [
@@ -129,27 +126,17 @@ const handler = defineRoute({
         contentType: 'application/json',
         schema: z.object({
           foo: z.string(),
-          bar: z.number(),
-          query: z.object({
-            test: z.string()
-          })
+          bar: z.number()
         })
       }
     ],
     // A strongly-typed Route Handler: https://nextjs.org/docs/app/building-your-application/routing/route-handlers
-    handler: async (
-      req,
-      {
-        params: {
-          test // Strongly typed.
-        }
-      }
-    ) => {
+    handler: async (req) => {
       const { foo, bar } = await req.json();
 
       // Any other JSON format will lead to TS error.
       return NextResponse.json(
-        { foo, bar, query: { test } },
+        { foo, bar },
         {
           status: 201
         }
@@ -193,9 +180,6 @@ export default defineApiRoute({
       body: z.object({
         foo: z.string(),
         bar: z.number()
-      }),
-      query: z.object({
-        test: z.string()
       })
     },
     output: [
@@ -204,15 +188,12 @@ export default defineApiRoute({
         contentType: 'application/json',
         schema: z.object({
           foo: z.string(),
-          bar: z.number(),
-          query: z.object({
-            test: z.string()
-          })
+          bar: z.number()
         })
       }
     ],
-    handler: ({ body: { foo, bar }, query: { test } }, res) => {
-      res.status(201).json({ foo, bar, query: { test } });
+    handler: ({ body: { foo, bar } }, res) => {
+      res.status(201).json({ foo, bar });
     }
   }
 });

--- a/packages/next-rest-framework/README.md
+++ b/packages/next-rest-framework/README.md
@@ -193,9 +193,6 @@ const handler = defineRoute({
       body: z.object({
         foo: z.string(),
         bar: z.number()
-      }),
-      query: z.object({
-        test: z.string()
       })
     },
     output: [
@@ -204,27 +201,17 @@ const handler = defineRoute({
         contentType: 'application/json',
         schema: z.object({
           foo: z.string(),
-          bar: z.number(),
-          query: z.object({
-            test: z.string()
-          })
+          bar: z.number()
         })
       }
     ],
     // A strongly-typed Route Handler: https://nextjs.org/docs/app/building-your-application/routing/route-handlers
-    handler: async (
-      req,
-      {
-        params: {
-          test // Strongly typed.
-        }
-      }
-    ) => {
+    handler: async (req) => {
       const { foo, bar } = await req.json();
 
       // Any other JSON format will lead to TS error.
       return NextResponse.json(
-        { foo, bar, query: { test } },
+        { foo, bar },
         {
           status: 201
         }
@@ -268,9 +255,6 @@ export default defineApiRoute({
       body: z.object({
         foo: z.string(),
         bar: z.number()
-      }),
-      query: z.object({
-        test: z.string()
       })
     },
     output: [
@@ -279,17 +263,15 @@ export default defineApiRoute({
         contentType: 'application/json',
         schema: z.object({
           foo: z.string(),
-          bar: z.number(),
-          query: z.object({
-            test: z.string()
-          })
+          bar: z.number()
         })
       }
     ],
-    handler: ({ body: { foo, bar }, query: { test } }, res) => {
-      res.status(201).json({ foo, bar, query: { test } });
+    handler: ({ body: { foo, bar } }, res) => {
+      res.status(201).json({ foo, bar });
     }
   }
+});
 ```
 
 These type-safe endpoints will be now auto-generated to your OpenAPI spec and Swagger UI!

--- a/packages/next-rest-framework/src/define-api-route.ts
+++ b/packages/next-rest-framework/src/define-api-route.ts
@@ -149,39 +149,33 @@ ${error}`);
           }
 
           if (bodySchema) {
-            const validateBody = await validateSchema?.({
+            const { valid, errors } = await validateSchema({
               schema: bodySchema,
               obj: body
             });
 
-            if (validateBody) {
-              const { valid, errors } = validateBody;
-
-              if (!valid) {
-                res
-                  .status(400)
-                  .json({ message: `Invalid request body: ${errors}` });
-                return;
-              }
+            if (!valid) {
+              res.status(400).json({
+                message: 'Invalid request body.',
+                errors
+              });
+              return;
             }
           }
 
           if (querySchema) {
-            const validateQuery = await validateSchema?.({
+            const { valid, errors } = await validateSchema({
               schema: querySchema,
               obj: query
             });
 
-            if (validateQuery) {
-              const { valid, errors } = validateQuery;
+            if (!valid) {
+              res.status(400).json({
+                message: 'Invalid query parameters.',
+                errors
+              });
 
-              if (!valid) {
-                res
-                  .status(400)
-                  .json({ message: `Invalid query parameters: ${errors}` });
-
-                return;
-              }
+              return;
             }
           }
         }

--- a/packages/next-rest-framework/src/define-route.ts
+++ b/packages/next-rest-framework/src/define-route.ts
@@ -157,48 +157,54 @@ ${error}`);
           }
 
           if (bodySchema) {
-            const body = await req.json();
+            try {
+              const reqClone = req.clone();
+              const body = await reqClone.json();
 
-            const validateBody = await validateSchema?.({
-              schema: bodySchema,
-              obj: body
-            });
-
-            if (validateBody) {
-              const { valid, errors } = validateBody;
+              const { valid, errors } = await validateSchema({
+                schema: bodySchema,
+                obj: body
+              });
 
               if (!valid) {
                 return NextResponse.json(
                   {
-                    message: `Invalid request body: ${errors}`
+                    message: 'Invalid request body.',
+                    errors
                   },
                   {
                     status: 400
                   }
                 );
               }
+            } catch (error) {
+              return NextResponse.json(
+                {
+                  message: 'Missing request body.'
+                },
+                {
+                  status: 400
+                }
+              );
             }
           }
 
           if (querySchema) {
-            const validateQuery = await validateSchema?.({
+            const { valid, errors } = await validateSchema({
               schema: querySchema,
               obj: context.params
             });
 
-            if (validateQuery) {
-              const { valid, errors } = validateQuery;
-
-              if (!valid) {
-                return NextResponse.json(
-                  {
-                    message: `Invalid query parameters: ${errors}`
-                  },
-                  {
-                    status: 400
-                  }
-                );
-              }
+            if (!valid) {
+              return NextResponse.json(
+                {
+                  message: 'Invalid query parameters.',
+                  errors
+                },
+                {
+                  status: 400
+                }
+              );
             }
           }
         }

--- a/packages/next-rest-framework/src/utils/schemas.ts
+++ b/packages/next-rest-framework/src/utils/schemas.ts
@@ -43,10 +43,7 @@ const zodSchemaValidator = ({
   obj: unknown;
 }) => {
   const data = schema.safeParse(obj);
-
-  const errors = !data.success
-    ? data.error.issues.map(({ message }) => message)
-    : null;
+  const errors = !data.success ? data.error.issues : null;
 
   return {
     valid: data.success,


### PR DESCRIPTION
When using App Route and the NextRequest
to validate the request body, we need to clone
the request object to validate the body to allow
further parsing of the request body. Before this
change, trying to parse the request body in the
request handler resulted in an error if the request
body was already parsed by the request body
validation logic.