### PR TITLE
Fix `appDirPath` handling when not using src directory

### DIFF
--- a/apps/example/src/next-rest-framework/client.ts
+++ b/apps/example/src/next-rest-framework/client.ts
@@ -6,8 +6,8 @@ export const {
   defineCatchAllApiRoute,
   defineApiRoute
 } = NextRestFramework({
-  appDirPath: 'src/app',
-  apiRoutesPath: 'src/pages/api',
+  appDirPath: './src/app',
+  apiRoutesPath: './src/pages/api',
   deniedPaths: ['/api/*/some-api'],
   openApiJsonPath: '/api/foo/openapi.json',
   openApiYamlPath: '/api/bar/openapi.yaml'

--- a/docs/docs/getting-started.md
+++ b/docs/docs/getting-started.md
@@ -16,7 +16,7 @@ App Router:
 import { NextRestFramework } from 'next-rest-framework';
 
 export const { defineCatchAllRoute, defineRoute } = NextRestFramework({
-  appDirPath: 'src/app', // Path to your app directory.
+  appDirPath: './src/app', // Path to your app directory.
   deniedPaths: ['/api/auth/**'] // Paths that are not using Next REST Framework if you have any.
 });
 ```
@@ -29,7 +29,7 @@ Pages Router:
 import { NextRestFramework } from 'next-rest-framework';
 
 export const { defineCatchAllApiRoute, defineApiRoute } = NextRestFramework({
-  apiRoutesPath: 'src/pages/api', // Path to your API routes directory.
+  apiRoutesPath: './src/pages/api', // Path to your API routes directory.
   deniedPaths: ['/api/auth/**'] // Paths that are not using Next REST Framework if you have any.
 });
 ```

--- a/packages/next-rest-framework/README.md
+++ b/packages/next-rest-framework/README.md
@@ -91,7 +91,7 @@ App Router:
 import { NextRestFramework } from 'next-rest-framework';
 
 export const { defineCatchAllRoute, defineRoute } = NextRestFramework({
-  appDirPath: 'src/app', // Path to your app directory.
+  appDirPath: './src/app', // Path to your app directory.
   deniedPaths: ['/api/auth/**'] // Paths that are not using Next REST Framework if you have any.
 });
 ```
@@ -104,7 +104,7 @@ Pages Router:
 import { NextRestFramework } from 'next-rest-framework';
 
 export const { defineCatchAllApiRoute, defineApiRoute } = NextRestFramework({
-  apiRoutesPath: 'src/pages/api', // Path to your API routes directory.
+  apiRoutesPath: './src/pages/api', // Path to your API routes directory.
   deniedPaths: ['/api/auth/**'] // Paths that are not using Next REST Framework if you have any.
 });
 ```

--- a/packages/next-rest-framework/src/types/config.ts
+++ b/packages/next-rest-framework/src/types/config.ts
@@ -11,6 +11,14 @@ type NextRestFrameworkOpenApiSpec = Partial<
   >
 >;
 
+type AppDirPath = 'app' | `app/${string}` | 'src/app' | `src/app/${string}`;
+
+type ApiRoutesPath =
+  | 'pages/api'
+  | `pages/api/${string}`
+  | 'src/pages/api'
+  | `src/pages/api/${string}`;
+
 export interface NextRestFrameworkConfig {
   /*!
    * Absolute path from the project root to the root directory where your Routes are located when using App Router.
@@ -18,18 +26,14 @@ export interface NextRestFrameworkConfig {
    * as possible will improve performance. This option is not required when using Pages Router, but it can be used
    * together with the `apiRoutesPath` option when using both routers at the same time.
    */
-  appDirPath?: 'app' | `app/${string}` | 'src/app' | `src/app/${string}`;
+  appDirPath?: AppDirPath | `/${AppDirPath}` | `./${AppDirPath}`;
   /*!
    * Absolute path from the project root to the root directory where your API Routes are located when using Pages Router.
    * Next REST Framework uses this as the root directory to recursively search for your API Routes, so being as specific
    * as possible will improve performance. This option is not required when using App Router, but it can be used
    * together with the `appDirPath` option when using both routers at the same time.
    */
-  apiRoutesPath?:
-    | 'pages/api'
-    | `pages/api/${string}`
-    | 'src/pages/api'
-    | `src/pages/api/${string}`;
+  apiRoutesPath?: ApiRoutesPath | `/${ApiRoutesPath}` | `./${ApiRoutesPath}`;
   /*!
    * Array of paths that are denied by Next REST Framework and not included in the OpenAPI spec.
    * Supports wildcards using asterisk `*` and double asterisk `**` for recursive matching.

--- a/packages/next-rest-framework/src/utils/open-api.ts
+++ b/packages/next-rest-framework/src/utils/open-api.ts
@@ -244,7 +244,7 @@ const generatePaths = async ({
       ? getNestedRoutes(join(process.cwd(), appDirPath ?? ''), '')
           .filter(filterRoutes)
           .map((file) =>
-            `${appDirPath.split('/app')[1]}/${file}`
+            `${appDirPath.split('app')[1]}/${file}`
               .replace('/route.ts', '')
               .replace(/\\/g, '/')
               .replace('[', '{')


### PR DESCRIPTION
There is a bug when not using the src directory and using the App Router - if the user does not define the `appDirPath` config option having a slash as prefix, the framework won't be able to find the route handlers. This fixes that with a one-line change in the route discovery logic.

The typings for both `appDirPath` and `apiRoutesPath` options are also changed so that the following formats are now supported:
- `src/app`
- `/src/app`
- `./src/app`