### PR TITLE
Fix App Route Query parameter

### DIFF
--- a/packages/next-rest-framework/src/define-route.ts
+++ b/packages/next-rest-framework/src/define-route.ts
@@ -192,7 +192,7 @@ ${error}`);
           if (querySchema) {
             const { valid, errors } = await validateSchema({
               schema: querySchema,
-              obj: context.params
+              obj: Object.fromEntries(new URLSearchParams(req.nextUrl.search))
             });
 
             if (!valid) {


### PR DESCRIPTION
Validating the input query schema (like seen below) was always returning an error, because the query parameters were not correctly read from the request.
I am not sure if this fix is the correct way, happy if you take over this pr.

```
    input: {
      query: z.object({
        foo: z.string()
      })
    },
```