### PR TITLE
Fix content type validation

### DIFF
--- a/packages/next-rest-framework/src/define-api-route.ts
+++ b/packages/next-rest-framework/src/define-api-route.ts
@@ -143,7 +143,10 @@ ${error}`);
         if (input) {
           const { body: bodySchema, query: querySchema, contentType } = input;
 
-          if (headers['content-type']?.split(';')[0] !== contentType) {
+          if (
+            contentType &&
+            headers['content-type']?.split(';')[0] !== contentType
+          ) {
             res.status(415).json({ message: DEFAULT_ERRORS.invalidMediaType });
             return;
           }

--- a/packages/next-rest-framework/src/define-route.ts
+++ b/packages/next-rest-framework/src/define-route.ts
@@ -149,7 +149,10 @@ ${error}`);
         if (input) {
           const { body: bodySchema, query: querySchema, contentType } = input;
 
-          if (headers.get('content-type')?.split(';')[0] !== contentType) {
+          if (
+            contentType &&
+            headers.get('content-type')?.split(';')[0] !== contentType
+          ) {
             return NextResponse.json(
               { message: DEFAULT_ERRORS.invalidMediaType },
               { status: 415 }


### PR DESCRIPTION
This fix changes the content type validation
so that it's done by the framework only when
the user has defined their desired content type
in the inputs. This should address some unexpected errors with various API clients that automatically set the content type header when the user has not set any header validations themselves.