### PR TITLE
Fix infinite request loop with pages router

### DIFF
--- a/packages/next-rest-framework/src/utils/open-api.ts
+++ b/packages/next-rest-framework/src/utils/open-api.ts
@@ -100,15 +100,14 @@ const generatePaths = async ({
   /*
    * Clean and filter the API routes to paths:
    * - Remove catch-all routes.
-   * - Remove the current route used for docs.
    * - Add the `/api` prefix.
    * - Replace back slashes, square brackets etc.
+   * - Filter the current route used for docs.
    * - Filter disallowed routes.
    */
   const getCleanedApiRoutes = (files: string[]) =>
     files
       .filter((file) => !file.includes('[...'))
-      .filter((file) => file !== `${url.split('/').at(-1)}.ts`)
       .map((file) =>
         `/api/${file}`
           .replace('/index', '')
@@ -117,6 +116,7 @@ const generatePaths = async ({
           .replace(']', '}')
           .replace('.ts', '')
       )
+      .filter((route) => route !== `/${url.split('/').at(-1)}`)
       .filter(isAllowedRoute);
 
   try {


### PR DESCRIPTION
This fixes a bug that caused an infinite request
loop when using pages router and the docs endpoint was not ignored by the OpenAPI path generation.

This fix also allows defining multiple different docs endpoints, although that should be a rare case.
The request protocol parsing is also now handled
differently with pages router and cases where the
protocol headers contain multiple protocols should be handled now.