### PR TITLE
Make CLI great again

### DIFF
--- a/apps/example/package.json
+++ b/apps/example/package.json
@@ -6,6 +6,7 @@
     "dev": "pnpm prebuild && next dev",
     "build": "pnpm prebuild && next build",
     "generate": "pnpm prebuild && next-rest-framework generate",
+    "validate": "pnpm prebuild && next-rest-framework validate",
     "start": "next start",
     "type-check": "tsc --noEmit"
   },

--- a/apps/example/public/openapi.json
+++ b/apps/example/public/openapi.json
@@ -17,15 +17,9 @@
                   "items": {
                     "type": "object",
                     "properties": {
-                      "id": {
-                        "type": "number"
-                      },
-                      "name": {
-                        "type": "string"
-                      },
-                      "completed": {
-                        "type": "boolean"
-                      }
+                      "id": { "type": "number" },
+                      "name": { "type": "string" },
+                      "completed": { "type": "boolean" }
                     },
                     "required": ["id", "name", "completed"],
                     "additionalProperties": false
@@ -40,11 +34,7 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "properties": {
-                    "message": {
-                      "type": "string"
-                    }
-                  }
+                  "properties": { "message": { "type": "string" } }
                 }
               }
             }
@@ -59,11 +49,7 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "properties": {
-                  "name": {
-                    "type": "string"
-                  }
-                },
+                "properties": { "name": { "type": "string" } },
                 "required": ["name"],
                 "additionalProperties": false
               }
@@ -73,11 +59,7 @@
         "responses": {
           "201": {
             "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
+              "application/json": { "schema": { "type": "string" } }
             }
           },
           "default": {
@@ -86,11 +68,7 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "properties": {
-                    "message": {
-                      "type": "string"
-                    }
-                  }
+                  "properties": { "message": { "type": "string" } }
                 }
               }
             }
@@ -109,15 +87,9 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "id": {
-                      "type": "number"
-                    },
-                    "name": {
-                      "type": "string"
-                    },
-                    "completed": {
-                      "type": "boolean"
-                    }
+                    "id": { "type": "number" },
+                    "name": { "type": "string" },
+                    "completed": { "type": "boolean" }
                   },
                   "required": ["id", "name", "completed"],
                   "additionalProperties": false
@@ -127,11 +99,7 @@
           },
           "404": {
             "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
+              "application/json": { "schema": { "type": "string" } }
             }
           },
           "default": {
@@ -140,23 +108,13 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "properties": {
-                    "message": {
-                      "type": "string"
-                    }
-                  }
+                  "properties": { "message": { "type": "string" } }
                 }
               }
             }
           }
         },
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true
-          }
-        ],
+        "parameters": [{ "name": "id", "in": "path", "required": true }],
         "operationId": "getTodoById",
         "tags": ["example-api", "todos", "pages-router"]
       },
@@ -164,20 +122,12 @@
         "responses": {
           "204": {
             "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
+              "application/json": { "schema": { "type": "string" } }
             }
           },
           "404": {
             "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
+              "application/json": { "schema": { "type": "string" } }
             }
           },
           "default": {
@@ -186,23 +136,13 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "properties": {
-                    "message": {
-                      "type": "string"
-                    }
-                  }
+                  "properties": { "message": { "type": "string" } }
                 }
               }
             }
           }
         },
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true
-          }
-        ],
+        "parameters": [{ "name": "id", "in": "path", "required": true }],
         "operationId": "deleteTodo",
         "tags": ["example-api", "todos", "pages-router"]
       }
@@ -218,15 +158,9 @@
                   "items": {
                     "type": "object",
                     "properties": {
-                      "id": {
-                        "type": "number"
-                      },
-                      "name": {
-                        "type": "string"
-                      },
-                      "completed": {
-                        "type": "boolean"
-                      }
+                      "id": { "type": "number" },
+                      "name": { "type": "string" },
+                      "completed": { "type": "boolean" }
                     },
                     "required": ["id", "name", "completed"],
                     "additionalProperties": false
@@ -241,11 +175,7 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "properties": {
-                    "message": {
-                      "type": "string"
-                    }
-                  }
+                  "properties": { "message": { "type": "string" } }
                 }
               }
             }
@@ -260,11 +190,7 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "properties": {
-                  "name": {
-                    "type": "string"
-                  }
-                },
+                "properties": { "name": { "type": "string" } },
                 "required": ["name"],
                 "additionalProperties": false
               }
@@ -274,11 +200,7 @@
         "responses": {
           "201": {
             "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
+              "application/json": { "schema": { "type": "string" } }
             }
           },
           "default": {
@@ -287,11 +209,7 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "properties": {
-                    "message": {
-                      "type": "string"
-                    }
-                  }
+                  "properties": { "message": { "type": "string" } }
                 }
               }
             }
@@ -310,15 +228,9 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "id": {
-                      "type": "number"
-                    },
-                    "name": {
-                      "type": "string"
-                    },
-                    "completed": {
-                      "type": "boolean"
-                    }
+                    "id": { "type": "number" },
+                    "name": { "type": "string" },
+                    "completed": { "type": "boolean" }
                   },
                   "required": ["id", "name", "completed"],
                   "additionalProperties": false
@@ -328,11 +240,7 @@
           },
           "404": {
             "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
+              "application/json": { "schema": { "type": "string" } }
             }
           },
           "default": {
@@ -341,23 +249,13 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "properties": {
-                    "message": {
-                      "type": "string"
-                    }
-                  }
+                  "properties": { "message": { "type": "string" } }
                 }
               }
             }
           }
         },
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true
-          }
-        ],
+        "parameters": [{ "name": "id", "in": "path", "required": true }],
         "operationId": "getTodoById",
         "tags": ["example-api", "todos", "app-router"]
       },
@@ -365,20 +263,12 @@
         "responses": {
           "204": {
             "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
+              "application/json": { "schema": { "type": "string" } }
             }
           },
           "404": {
             "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
+              "application/json": { "schema": { "type": "string" } }
             }
           },
           "default": {
@@ -387,23 +277,13 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "properties": {
-                    "message": {
-                      "type": "string"
-                    }
-                  }
+                  "properties": { "message": { "type": "string" } }
                 }
               }
             }
           }
         },
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true
-          }
-        ],
+        "parameters": [{ "name": "id", "in": "path", "required": true }],
         "operationId": "deleteTodo",
         "tags": ["example-api", "todos", "app-router"]
       }

--- a/docs/docs/api-reference.md
+++ b/docs/docs/api-reference.md
@@ -17,7 +17,6 @@ The following options can be passed to the `docsRouteHandler` (App Router) and `
 | `autoGenerateOpenApiSpec` | Setting this to `false` will not automatically update the generated OpenAPI spec when calling the Next REST Framework endpoint. Defaults to `true`.                                                                                                                                                                    |
 | `docsConfig`              | A [Docs config](#docs-config) object for customizing the generated docs.                                                                                                                                                                                                                                               |
 | `suppressInfo`            | Setting this to `true` will suppress all informational logs from Next REST Framework. Defaults to `false`.                                                                                                                                                                                                             |
-| `generatePathsTimeout`    | Timeout in milliseconds for generating the OpenAPI spec. Defaults to 5000. For large applications you might have to increase this.                                                                                                                                                                                     |
 
 ### [Docs config](#docs-config)
 
@@ -40,7 +39,7 @@ The following options cam be passed to the `routeHandler` (App Router) and `apiR
 | `GET \| PUT \| POST \| DELETE \| OPTIONS \| HEAD \| PATCH` | A [Method handler](#method-handlers) object.                                                                                                                | `true`   |
 | `openApiPath`                                              | An OpenAPI [Path Item Object](https://swagger.io/specification/#path-item-object) that can be used to override and extend the auto-generated specification. | `false`  |
 
-#### [Route operations](#route-operations)
+### [Route operations](#route-operations)
 
 The route operation functions `routeOperation` (App Router) and `apiRouteOperation` (Pages Router) allow you to define your API handlers for your endpoints. These functions accept an OpenAPI [Operation object](https://swagger.io/specification/#operation-object) as a parameter, that can be used to override the auto-generated specification. Calling this function allows you to chain your API handler logic with the following functions.
 
@@ -50,7 +49,7 @@ The route operation functions `routeOperation` (App Router) and `apiRouteOperati
 | `output`  | An [Output](#output) function for defining the validation and documentation of the response. |
 | `handler` | A [Handler](#handler) function for defining your business logic.                             |
 
-##### [Input](#input)
+#### [Input](#input)
 
 The input function is used for validation and documentation of the request, taking in an object with the following properties:
 
@@ -62,7 +61,7 @@ The input function is used for validation and documentation of the request, taki
 
 Calling the input function allows you to chain your API handler logic with the [Output](#output) and [Handler](#handler) functions.
 
-##### [Output](#output)
+#### [Output](#output)
 
 The output function is used for validation and documentation of the response, taking in an array of objects with the following properties:
 
@@ -74,6 +73,22 @@ The output function is used for validation and documentation of the response, ta
 
 Calling the input function allows you to chain your API handler logic with the [Handler](#handler) function.
 
-##### [Handler](#handler)
+#### [Handler](#handler)
 
 The handler function is a strongly-typed function to implement the business logic for your API. The function takes in strongly-typed versions of the same parameters as the Next.js [Route Handlers](https://nextjs.org/docs/app/building-your-application/routing/route-handlers) and [API Routes](https://nextjs.org/docs/pages/building-your-application/routing/api-routes) handlers.
+
+## [CLI](#cli)
+
+The Next REST Framework CLI supports generating and validating the `openapi.json` file:
+
+- `npx next-rest-framework generate` to generate the `openapi.json` file.
+- `npx next-rest-framework validate` to validate that the generated OpenAPI spec matches the previously generated `openapi.json` file.
+
+The `next-rest-framework validate` command is useful to have as part of the static checks in your CI/CD pipeline. Both commands support the following options:
+
+| Name                    | Description                                                                                                                                                                                    |
+| ----------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --- |
+| `--skipBuild <boolean>` | By default this command runs `next build` to build your routes. If you have already created the build, you can skip this step by setting this to `true`.                                       |
+| `--distDir <string>`    | Path to your production build directory. Defaults to `.next`.                                                                                                                                  |
+| `--timeout <string>`    | The timeout for generating the OpenAPI spec. Defaults to 60 seconds.                                                                                                                           |     |
+| `--configPath <string>` | In case you have multiple docs handlers with different configurations, you can specify which configuration you want to use by providing the path to the API. Example: `/api/my-configuration`. |     |

--- a/packages/next-rest-framework/README.md
+++ b/packages/next-rest-framework/README.md
@@ -42,10 +42,11 @@
   - [Docs handler options](#docs-handler-options)
   - [Docs config](#docs-config)
   - [Route handler options](#route-handler-options)
-    - [Route operations](#route-operations)
-      - [Input](#input)
-      - [Output](#output)
-      - [Handler](#handler)
+  - [Route operations](#route-operations)
+    - [Input](#input)
+    - [Output](#output)
+    - [Handler](#handler)
+- [CLI](#cli)
 - [Changelog](#changelog)
 - [Contributing](#contributing)
 - [License](#license)
@@ -106,7 +107,7 @@ import { docsApiRouteHandler } from 'next-rest-framework';
 export default docsApiRouteHandler();
 ```
 
-This is enough to get you started. Now you can access the API documentation in your browser. Calling this endpoint will automatically generate the `openapi.json` OpenAPI specification file, located in the `public` folder by default. You can also configure this endpoint to disable the automatic generation of the OpenAPI spec file or use the CLI command `npx next-rest-framework generate` to generate it. You can also create multiple docs endpoints for various use cases. See the full configuration options of this endpoint in the [Docs handler](#docs-handler-options) section.
+This is enough to get you started. Now you can access the API documentation in your browser. Calling this endpoint will automatically generate the `openapi.json` OpenAPI specification file, located in the `public` folder by default. You can also configure this endpoint to disable the automatic generation of the OpenAPI spec file or use the [CLI](#cli) command `npx next-rest-framework generate` to generate it. You can also create multiple docs endpoints for various use cases. See the full configuration options of this endpoint in the [Docs handler](#docs-handler-options) section.
 
 ### [Create endpoint](#create-endpoint)
 
@@ -265,7 +266,6 @@ The following options can be passed to the `docsRouteHandler` (App Router) and `
 | `autoGenerateOpenApiSpec` | Setting this to `false` will not automatically update the generated OpenAPI spec when calling the Next REST Framework endpoint. Defaults to `true`.                                                                                                                                                                    |
 | `docsConfig`              | A [Docs config](#docs-config) object for customizing the generated docs.                                                                                                                                                                                                                                               |
 | `suppressInfo`            | Setting this to `true` will suppress all informational logs from Next REST Framework. Defaults to `false`.                                                                                                                                                                                                             |
-| `generatePathsTimeout`    | Timeout in milliseconds for generating the OpenAPI spec. Defaults to 5000. For large applications you might have to increase this.                                                                                                                                                                                     |
 
 ### [Docs config](#docs-config)
 
@@ -288,7 +288,7 @@ The following options cam be passed to the `routeHandler` (App Router) and `apiR
 | `GET \| PUT \| POST \| DELETE \| OPTIONS \| HEAD \| PATCH` | A [Method handler](#method-handlers) object.                                                                                                                | `true`   |
 | `openApiPath`                                              | An OpenAPI [Path Item Object](https://swagger.io/specification/#path-item-object) that can be used to override and extend the auto-generated specification. | `false`  |
 
-#### [Route operations](#route-operations)
+### [Route operations](#route-operations)
 
 The route operation functions `routeOperation` (App Router) and `apiRouteOperation` (Pages Router) allow you to define your API handlers for your endpoints. These functions accept an OpenAPI [Operation object](https://swagger.io/specification/#operation-object) as a parameter, that can be used to override the auto-generated specification. Calling this function allows you to chain your API handler logic with the following functions.
 
@@ -298,7 +298,7 @@ The route operation functions `routeOperation` (App Router) and `apiRouteOperati
 | `output`  | An [Output](#output) function for defining the validation and documentation of the response. |
 | `handler` | A [Handler](#handler) function for defining your business logic.                             |
 
-##### [Input](#input)
+#### [Input](#input)
 
 The input function is used for validation and documentation of the request, taking in an object with the following properties:
 
@@ -310,7 +310,7 @@ The input function is used for validation and documentation of the request, taki
 
 Calling the input function allows you to chain your API handler logic with the [Output](#output) and [Handler](#handler) functions.
 
-##### [Output](#output)
+#### [Output](#output)
 
 The output function is used for validation and documentation of the response, taking in an array of objects with the following properties:
 
@@ -322,9 +322,25 @@ The output function is used for validation and documentation of the response, ta
 
 Calling the input function allows you to chain your API handler logic with the [Handler](#handler) function.
 
-##### [Handler](#handler)
+#### [Handler](#handler)
 
 The handler function is a strongly-typed function to implement the business logic for your API. The function takes in strongly-typed versions of the same parameters as the Next.js [Route Handlers](https://nextjs.org/docs/app/building-your-application/routing/route-handlers) and [API Routes](https://nextjs.org/docs/pages/building-your-application/routing/api-routes) handlers.
+
+## [CLI](#cli)
+
+The Next REST Framework CLI supports generating and validating the `openapi.json` file:
+
+- `npx next-rest-framework generate` to generate the `openapi.json` file.
+- `npx next-rest-framework validate` to validate that the generated OpenAPI spec matches the previously generated `openapi.json` file.
+
+The `next-rest-framework validate` command is useful to have as part of the static checks in your CI/CD pipeline. Both commands support the following options:
+
+| Name                    | Description                                                                                                                                                                                    |
+| ----------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --- |
+| `--skipBuild <boolean>` | By default this command runs `next build` to build your routes. If you have already created the build, you can skip this step by setting this to `true`.                                       |
+| `--distDir <string>`    | Path to your production build directory. Defaults to `.next`.                                                                                                                                  |
+| `--timeout <string>`    | The timeout for generating the OpenAPI spec. Defaults to 60 seconds.                                                                                                                           |     |
+| `--configPath <string>` | In case you have multiple docs handlers with different configurations, you can specify which configuration you want to use by providing the path to the API. Example: `/api/my-configuration`. |     |
 
 ## [Changelog](#changelog)
 

--- a/packages/next-rest-framework/package.json
+++ b/packages/next-rest-framework/package.json
@@ -28,7 +28,7 @@
     "preinstall": "mkdir -p dist && touch ./dist/cli.js && echo \"#!/usr/bin/env node\" > ./dist/cli.js",
     "type-check": "tsc --noEmit",
     "build": "rm -rf dist && tsc --project tsconfig.build.json",
-    "test": "jest",
+    "test": "node --experimental-vm-modules ./node_modules/jest/bin/jest.js",
     "test:watch": "jest --watch"
   },
   "bin": {
@@ -38,6 +38,7 @@
     "chalk": "4.1.2",
     "commander": "10.0.1",
     "lodash": "4.17.21",
+    "prettier": "3.0.2",
     "wait-on": "7.0.1",
     "zod-to-json-schema": "3.21.4"
   },

--- a/packages/next-rest-framework/src/cli.ts
+++ b/packages/next-rest-framework/src/cli.ts
@@ -1,50 +1,461 @@
 #!/usr/bin/env node
 
 import { Command } from 'commander';
-import chalk from 'chalk';
-
-import waitOn from 'wait-on';
 import { spawn } from 'child_process';
+import waitOn from 'wait-on';
+import { join } from 'path';
+import chalk from 'chalk';
+import { type NextRestFrameworkConfig } from './types';
+import { type OpenAPIV3_1 } from 'openapi-types';
+import {
+  getApiRouteName,
+  getNestedFiles,
+  getRouteName,
+  getSortedPaths,
+  isValidMethod,
+  isWildcardMatch,
+  logIgnoredPaths,
+  syncOpenApiSpec
+} from './utils';
+import { existsSync, readFileSync } from 'fs';
+import { isEqualWith, merge } from 'lodash';
+import { OPEN_API_VERSION } from './constants';
+
+// Generate the OpenAPI paths from the Next.js routes and API routes from the build output.
+const generatePathsFromBuild = async ({
+  config,
+  distDir
+}: {
+  config: Required<NextRestFrameworkConfig>;
+  distDir: string;
+}): Promise<OpenAPIV3_1.PathsObject> => {
+  const ignoredPaths: string[] = [];
+
+  // Check if the route is allowed or denied by the user.
+  const isAllowedRoute = (path: string) => {
+    const isAllowed = config.allowedPaths.some((allowedPath) =>
+      isWildcardMatch({ pattern: allowedPath, path })
+    );
+
+    const isDenied = config.deniedPaths.some((deniedPath) =>
+      isWildcardMatch({ pattern: deniedPath, path })
+    );
+
+    const routeIsAllowed = isAllowed && !isDenied;
+
+    if (!routeIsAllowed) {
+      ignoredPaths.push(path);
+    }
+
+    return routeIsAllowed;
+  };
+
+  /*
+   * Clean and filter the routes to paths:
+   * - Remove any routes that are not API routes.
+   * - Remove catch-all routes.
+   * - Replace back slashes, square brackets etc.
+   * - Filter disallowed routes.
+   */
+  const getCleanedRoutes = (files: string[]) =>
+    files
+      .filter((file) => file.endsWith('route.js'))
+      .filter((file) => !file.includes('[...'))
+      .filter((file) => isAllowedRoute(getRouteName(file)));
+
+  /*
+   * Clean and filter the API routes to paths:
+   * - Remove catch-all routes.
+   * - Add the `/api` prefix.
+   * - Replace back slashes, square brackets etc.
+   * - Filter disallowed routes.
+   */
+  const getCleanedApiRoutes = (files: string[]) =>
+    files
+      .filter((file) => !file.includes('[...'))
+      .filter((file) => isAllowedRoute(getApiRouteName(file)));
+
+  const isPathItem = (
+    obj: unknown
+  ): obj is Record<string, OpenAPIV3_1.PathItemObject> =>
+    typeof obj === 'object';
+
+  let paths: OpenAPIV3_1.PathsObject = {};
+
+  try {
+    // Scan `app` folder.
+    const path = join(process.cwd(), distDir, 'server/app');
+
+    if (existsSync(path)) {
+      const routes = getCleanedRoutes(getNestedFiles(path, ''));
+
+      await Promise.all(
+        routes.map(async (route) => {
+          const res = await import(
+            join(process.cwd(), distDir, 'server/app', route)
+          );
+
+          Object.entries(res.routeModule.userland)
+            .filter(([key]) => isValidMethod(key))
+            .forEach(([_key, handler]: [string, any]) => {
+              const data = handler.getPaths(getRouteName(route));
+
+              if (isPathItem(data)) {
+                paths = { ...paths, ...data };
+              }
+            });
+        })
+      );
+    }
+  } catch {
+    // Route was not a route handler.
+  }
+
+  try {
+    // Scan `pages/api` folder.
+    const path = join(process.cwd(), distDir, 'server/pages/api');
+
+    if (existsSync(path)) {
+      const apiRoutes = getCleanedApiRoutes(getNestedFiles(path, ''));
+
+      await Promise.all(
+        apiRoutes.map(async (apiRoute) => {
+          const res = await import(
+            join(process.cwd(), distDir, 'server/pages/api', apiRoute)
+          );
+
+          const data = res.default.getPaths(getApiRouteName(apiRoute));
+
+          if (isPathItem(data)) {
+            paths = { ...paths, ...data };
+          }
+        })
+      );
+    }
+  } catch {
+    // Route was not an API route handler.
+  }
+
+  if (ignoredPaths.length) {
+    logIgnoredPaths(ignoredPaths);
+  }
+
+  return getSortedPaths(paths);
+};
+
+const findConfig = async ({
+  distDir,
+  configPath
+}: {
+  distDir: string;
+  configPath?: string;
+}) => {
+  let config: Required<NextRestFrameworkConfig> | undefined;
+
+  try {
+    // Scan `app` folder.
+    const path = join(process.cwd(), distDir, 'server/app');
+
+    if (existsSync(path)) {
+      const filteredRoutes = getNestedFiles(path, '').filter((file) => {
+        if (configPath) {
+          return configPath === getRouteName(file);
+        }
+
+        return true;
+      });
+
+      await Promise.all(
+        filteredRoutes.map(async (file) => {
+          const res = await import(
+            join(process.cwd(), distDir, 'server/app', file)
+          );
+
+          Object.entries(res.routeModule.userland)
+            .filter(([key]) => isValidMethod(key))
+            .forEach(([_key, handler]: [string, any]) => {
+              const _config = handler.nextRestFrameworkConfig;
+
+              if (_config) {
+                config = _config;
+              }
+            });
+        })
+      );
+    }
+  } catch {
+    // Route was not a docs handler.
+  }
+
+  // Config found, no need to do a further scan.
+  if (config) {
+    return config;
+  }
+
+  try {
+    // Scan `pages/api` folder.
+    const path = join(process.cwd(), distDir, 'server/pages/api');
+
+    if (existsSync(path)) {
+      const filteredApiRoutes = getNestedFiles(path, '').filter((file) => {
+        if (configPath) {
+          return configPath === getApiRouteName(file);
+        }
+
+        return true;
+      });
+
+      await Promise.all(
+        filteredApiRoutes.map(async (file) => {
+          const res = await import(
+            join(process.cwd(), distDir, 'server/pages/api', file)
+          );
+
+          const _config = res.default.nextRestFrameworkConfig;
+
+          if (_config) {
+            config = _config;
+          }
+        })
+      );
+    }
+  } catch {
+    // API Route was not a docs handler.
+  }
+
+  return config;
+};
+
+// Sync the `openapi.json` file from generated paths from the build output.
+const syncOpenApiSpecFromBuild = async ({
+  distDir,
+  configPath
+}: {
+  distDir: string;
+  configPath?: string;
+}) => {
+  const config = await findConfig({ distDir, configPath });
+
+  if (!config && configPath) {
+    console.log(
+      chalk.red(
+        `A \`configPath\` parameter with a value of ${configPath} was provided but no Next REST Framework configs were found.`
+      )
+    );
+
+    return;
+  }
+
+  if (!config) {
+    console.log(
+      chalk.red(
+        'Next REST Framework config not found. Initialize a docs handler to generate the OpenAPI spec.'
+      )
+    );
+
+    return;
+  }
+
+  console.log(chalk.yellowBright('Next REST Framework config found!'));
+  const paths = await generatePathsFromBuild({ config, distDir });
+  await syncOpenApiSpec({ config, paths });
+};
+
+// Sync the `openapi.json` file from generated paths from the build output.
+const validateOpenApiSpecFromBuild = async ({
+  distDir,
+  configPath
+}: {
+  distDir: string;
+  configPath?: string;
+}) => {
+  const config = await findConfig({ distDir, configPath });
+
+  if (!config && configPath) {
+    console.log(
+      chalk.red(
+        `A \`configPath\` parameter with a value of ${configPath} was provided but no Next REST Framework configs were found.`
+      )
+    );
+
+    return;
+  }
+
+  if (!config) {
+    console.log(
+      chalk.red(
+        'Next REST Framework config not found. Initialize a docs handler to validate the OpenAPI spec.'
+      )
+    );
+
+    return;
+  }
+
+  console.log(chalk.yellowBright('Next REST Framework config found!'));
+
+  const paths = await generatePathsFromBuild({ config, distDir });
+  const path = join(process.cwd(), 'public', config.openApiJsonPath);
+
+  const newSpec = merge(
+    {
+      openapi: OPEN_API_VERSION
+    },
+    config.openApiObject,
+    { paths }
+  );
+
+  try {
+    const data = readFileSync(path);
+    const openApiSpec = JSON.parse(data.toString());
+
+    if (!isEqualWith(openApiSpec, newSpec)) {
+      console.error(
+        chalk.red(
+          'API spec changed is not up-to-date. Run `next-rest-framework generate` to update it.'
+        )
+      );
+    } else {
+      console.info(chalk.green('OpenAPI spec up to date!'));
+      return true;
+    }
+  } catch {
+    console.error(
+      chalk.red(
+        'No OpenAPI spec found. Run `next-rest-framework generate` to generate it.'
+      )
+    );
+  }
+
+  return false;
+};
 
 const program = new Command();
 
 program
   .command('generate')
   .option(
-    '--port <string>',
-    'The port in which you want to run your Next.js server during the generation. Defaults to 3000.'
+    '--skipBuild <boolean>',
+    'By default this command runs `next build` to build your routes. If you have already created the build, you can skip this step by setting this to `true`.'
   )
   .option(
-    '--path <string>',
-    'Path to the API endpoint that triggers the OpenAPI generation. Defaults to `/api`.'
+    '--distDir <string>',
+    'Path to your production build directory. Defaults to `.next`.'
   )
   .option(
     '--timeout <string>',
-    'The timeout for waiting on the Next.js server to start. Defaults to 10000ms.'
+    'The timeout for generating the OpenAPI spec. Defaults to 60 seconds.'
   )
-  .description(
-    'Run the OpenAPI generation from your Next REST Framework client.'
+  .option(
+    '--configPath <string>',
+    'In case you have multiple docs handlers with different configurations, you can specify which configuration you want to use by providing the path to the API. Example: `/api/my-configuration`.'
   )
+  .description('Generate an OpenAPI spec with Next REST Framework.')
   .action(async (options) => {
-    const port = options.port ?? '3000';
-    const path = options.path ?? '/api';
-    const timeout = options.timeout ?? 10000;
+    const skipBuild: boolean = options.skipBuild ?? false;
+    const distDir: string = options.distDir ?? '.next';
+    const timeout: number = options.timeout ?? 60000;
+    const configPath: string = options.configPath ?? '';
 
-    const server = spawn('npx', ['next', 'dev', '-p', port], {
-      stdio: 'inherit'
-    });
+    console.log(chalk.yellowBright('Generating OpenAPI spec...'));
 
-    try {
-      await waitOn({
-        resources: [`http-get://localhost:${port}${path}`],
-        timeout
-      });
+    if (!skipBuild) {
+      const server = spawn('npx', ['next', 'build']);
 
-      server.kill();
-    } catch (e) {
-      console.error(chalk.red(`Error while generating the API spec: ${e}`));
-      server.kill();
-      process.exit(1);
+      try {
+        await waitOn({
+          resources: [join(process.cwd(), distDir, 'BUILD_ID')],
+          timeout
+        });
+
+        server.kill();
+
+        await syncOpenApiSpecFromBuild({
+          distDir,
+          configPath
+        });
+      } catch (e) {
+        console.error(e);
+        server.kill();
+        process.exit(1);
+      }
+    } else {
+      try {
+        await syncOpenApiSpecFromBuild({
+          distDir,
+          configPath
+        });
+      } catch (e) {
+        console.error(e);
+        process.exit(1);
+      }
+    }
+  });
+
+program
+  .command('validate')
+  .option(
+    '--skipBuild <boolean>',
+    'By default this command runs `next build` to build your routes. If you have already created the build, you can skip this step by setting this to `true`.'
+  )
+  .option(
+    '--distDir <string>',
+    'Path to your production build directory. Defaults to `.next`.'
+  )
+  .option(
+    '--timeout <string>',
+    'The timeout for generating the OpenAPI spec. Defaults to 60 seconds.'
+  )
+  .option(
+    '--configPath <string>',
+    'In case you have multiple docs handlers with different configurations, you can specify which configuration you want to use by providing the path to the API. Example: `/api/my-configuration`.'
+  )
+  .description('Validate an OpenAPI spec with Next REST Framework.')
+  .action(async (options) => {
+    const skipBuild: boolean = options.skipBuild ?? false;
+    const distDir: string = options.distDir ?? '.next';
+    const timeout: number = options.timeout ?? 60000;
+    const server = spawn('npx', ['next', 'build']);
+    const configPath: string = options.configPath ?? '';
+
+    console.log(chalk.yellowBright('Validating OpenAPI spec...'));
+
+    if (!skipBuild) {
+      try {
+        await waitOn({
+          resources: [join(process.cwd(), distDir, 'BUILD_ID')],
+          timeout
+        });
+
+        server.kill();
+
+        const valid = await validateOpenApiSpecFromBuild({
+          distDir,
+          configPath
+        });
+
+        if (!valid) {
+          process.exit(1);
+        }
+      } catch (e) {
+        console.error(e);
+        server.kill();
+        process.exit(1);
+      }
+    } else {
+      try {
+        const valid = await validateOpenApiSpecFromBuild({
+          distDir,
+          configPath
+        });
+
+        if (!valid) {
+          process.exit(1);
+        }
+      } catch (e) {
+        console.error(e);
+        server.kill();
+        process.exit(1);
+      }
     }
   });
 

--- a/packages/next-rest-framework/src/global.d.ts
+++ b/packages/next-rest-framework/src/global.d.ts
@@ -1,6 +1,3 @@
 declare module globalThis {
   var nextRestFrameworkConfig;
-  var openApiSpec;
-  var apiSpecGeneratedLogged = false;
-  var ignoredPathsLogged = false;
 }

--- a/packages/next-rest-framework/src/route-handlers.ts
+++ b/packages/next-rest-framework/src/route-handlers.ts
@@ -22,7 +22,7 @@ import {
 } from 'next/types';
 
 export const routeHandler = (methodHandlers: RouteParams) => {
-  return async (req: NextRequest, context: { params: BaseQuery }) => {
+  const handler = async (req: NextRequest, context: { params: BaseQuery }) => {
     try {
       const { method, headers, nextUrl } = req;
       const { pathname } = nextUrl;
@@ -146,6 +146,14 @@ ${error}`);
       );
     }
   };
+
+  handler.getPaths = (route: string) =>
+    getPathsFromMethodHandlers({
+      methodHandlers,
+      route
+    });
+
+  return handler;
 };
 
 export const routeOperation: RouteOperation = (openApiOperation) => {
@@ -188,7 +196,7 @@ export const routeOperation: RouteOperation = (openApiOperation) => {
 };
 
 export const apiRouteHandler = (methodHandlers: ApiRouteParams) => {
-  return async (req: NextApiRequest, res: NextApiResponse) => {
+  const handler = async (req: NextApiRequest, res: NextApiResponse) => {
     try {
       const { method, body, query, headers, url: pathname } = req;
 
@@ -282,6 +290,14 @@ ${error}`);
       res.status(500).json({ message: DEFAULT_ERRORS.unexpectedError });
     }
   };
+
+  handler.getPaths = (route: string) =>
+    getPathsFromMethodHandlers({
+      methodHandlers,
+      route
+    });
+
+  return handler;
 };
 
 export const apiRouteOperation: ApiRouteOperation = (openApiOperation) => {

--- a/packages/next-rest-framework/src/types/config.ts
+++ b/packages/next-rest-framework/src/types/config.ts
@@ -44,6 +44,4 @@ export interface NextRestFrameworkConfig {
   };
   /*! Setting this to `true` will suppress all informational logs from Next REST Framework. Defaults to `false`. */
   suppressInfo?: boolean;
-  /*! Timeout in milliseconds for generating the OpenAPI spec. Defaults to 5000. For large applications you might have to increase this. */
-  generatePathsTimeout?: number;
 }

--- a/packages/next-rest-framework/src/utils/config.ts
+++ b/packages/next-rest-framework/src/utils/config.ts
@@ -8,7 +8,7 @@ import {
 } from '../constants';
 import { type NextRestFrameworkConfig } from '../types';
 
-export const DEFAULT_CONFIG: NextRestFrameworkConfig = {
+export const DEFAULT_CONFIG: Required<NextRestFrameworkConfig> = {
   deniedPaths: [],
   allowedPaths: ['**'],
   openApiObject: {
@@ -27,8 +27,7 @@ export const DEFAULT_CONFIG: NextRestFrameworkConfig = {
     faviconUrl: DEFAULT_FAVICON_URL,
     logoUrl: DEFAULT_LOGO_URL
   },
-  suppressInfo: false,
-  generatePathsTimeout: 5000
+  suppressInfo: false
 };
 
 export const getConfig = (config?: NextRestFrameworkConfig) =>

--- a/packages/next-rest-framework/src/utils/docs.ts
+++ b/packages/next-rest-framework/src/utils/docs.ts
@@ -16,11 +16,11 @@ export const getHtmlForDocs = ({
       description = openApiObject?.info.description ?? DEFAULT_DESCRIPTION,
       faviconUrl = DEFAULT_FAVICON_URL,
       logoUrl = DEFAULT_LOGO_URL
-    } = {}
+    }
   },
   baseUrl
 }: {
-  config: NextRestFrameworkConfig;
+  config: Required<NextRestFrameworkConfig>;
   baseUrl: string;
 }) => {
   const url = `${baseUrl}${openApiJsonPath}`;

--- a/packages/next-rest-framework/src/utils/logging.ts
+++ b/packages/next-rest-framework/src/utils/logging.ts
@@ -1,38 +1,4 @@
 import chalk from 'chalk';
-import { isEqualWith } from 'lodash';
-import { type NextRestFrameworkConfig } from '../types';
-
-export const logInitInfo = ({
-  config,
-  baseUrl,
-  url
-}: {
-  config: NextRestFrameworkConfig;
-  baseUrl: string;
-  url: string;
-}) => {
-  const configsEqual = isEqualWith(global.nextRestFrameworkConfig, config);
-
-  const logReservedPaths = () => {
-    console.info(
-      chalk.yellowBright(`Docs: ${url}
-OpenAPI JSON: ${baseUrl}${config.openApiJsonPath}`)
-    );
-  };
-
-  if (!global.nextRestFrameworkConfig) {
-    global.nextRestFrameworkConfig = config;
-    console.info(chalk.green('Next REST Framework initialized! 🚀'));
-    logReservedPaths();
-  } else if (!configsEqual) {
-    console.info(
-      chalk.green('Next REST Framework config changed, re-initializing!')
-    );
-
-    global.nextRestFrameworkConfig = config;
-    logReservedPaths();
-  }
-};
 
 export const logNextRestFrameworkError = (error: unknown) => {
   console.error(

--- a/packages/next-rest-framework/tests/app-router/index.test.ts
+++ b/packages/next-rest-framework/tests/app-router/index.test.ts
@@ -10,11 +10,12 @@ import {
   type NextRestFrameworkConfig
 } from '../../src/types';
 import { docsRouteHandler, routeHandler, routeOperation } from '../../src';
+import fs from 'fs';
 
 jest.mock('fs', () => ({
   ...jest.requireActual('fs'),
   readdirSync: () => [],
-  readFileSync: () => '',
+  readFileSync: () => Buffer.from(''), // No OpenAPI spec found.
   writeFileSync: () => {},
   existsSync: () => true
 }));
@@ -88,12 +89,12 @@ OpenAPI JSON: http://localhost:3000/openapi.json`)
 
   expect(console.info).toHaveBeenNthCalledWith(
     3,
-    chalk.yellowBright('No API spec found, generating openapi.json')
+    chalk.yellowBright('No OpenAPI spec found, generating `openapi.json`...')
   );
 
   expect(console.info).toHaveBeenNthCalledWith(
     4,
-    chalk.green('API spec generated successfully!')
+    chalk.green('OpenAPI spec generated successfully!')
   );
 
   expect(console.info).toHaveBeenCalledTimes(4);
@@ -103,6 +104,7 @@ OpenAPI JSON: http://localhost:3000/openapi.json`)
     path: '/api/foo/bar'
   }));
 
+  jest.spyOn(fs, 'readFileSync').mockImplementation(() => Buffer.from('{}')); // OpenAPI spec found.
   await docsRouteHandler({ openApiJsonPath: '/api/bar/baz' })(req, context);
 
   expect(console.info).toHaveBeenNthCalledWith(
@@ -116,7 +118,17 @@ OpenAPI JSON: http://localhost:3000/openapi.json`)
 OpenAPI JSON: http://localhost:3000/api/bar/baz`)
   );
 
-  expect(console.info).toHaveBeenCalledTimes(6);
+  expect(console.info).toHaveBeenNthCalledWith(
+    7,
+    chalk.yellowBright('OpenAPI spec changed, regenerating `openapi.json`...')
+  );
+
+  expect(console.info).toHaveBeenNthCalledWith(
+    8,
+    chalk.green('OpenAPI spec generated successfully!')
+  );
+
+  expect(console.info).toHaveBeenCalledTimes(8);
 });
 
 it.each(['redoc', 'swagger-ui'] satisfies DocsProvider[])(

--- a/packages/next-rest-framework/tests/app-router/paths.test.ts
+++ b/packages/next-rest-framework/tests/app-router/paths.test.ts
@@ -10,7 +10,6 @@ import {
 } from '../../src/constants';
 import { z } from 'zod';
 import { NextResponse } from 'next/server';
-import fs from 'fs';
 import chalk from 'chalk';
 import * as openApiUtils from '../../src/utils/open-api';
 import { docsRouteHandler, routeHandler, routeOperation } from '../../src';
@@ -37,9 +36,7 @@ jest.mock('fs', () => ({
   existsSync: () => true
 }));
 
-const writeFileSyncSpy = jest
-  .spyOn(fs, 'writeFileSync')
-  .mockImplementation(() => {});
+const generateOpenApiSpecSpy = jest.spyOn(openApiUtils, 'generateOpenApiSpec');
 
 jest.mock('path', () => ({
   ...jest.requireActual('path'),
@@ -203,8 +200,9 @@ it('auto-generates the paths from the internal endpoint responses', async () => 
     deniedPaths: []
   });
 
-  expect(global.openApiSpec).toEqual(spec);
-  expect(writeFileSyncSpy).toHaveBeenCalled();
+  expect(generateOpenApiSpecSpy).toHaveBeenCalledWith(
+    expect.objectContaining({ spec })
+  );
 });
 
 it.each([
@@ -275,8 +273,9 @@ it.each([
       deniedPaths: expectedPathsToBeDenied
     });
 
-    expect(global.openApiSpec).toEqual(spec);
-    expect(writeFileSyncSpy).toHaveBeenCalled();
+    expect(generateOpenApiSpecSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ spec })
+    );
 
     if (expectedPathsToBeDenied.length) {
       expect(console.info).toHaveBeenNthCalledWith(
@@ -363,8 +362,9 @@ it.each([
       deniedPaths: expectedPathsToBeDenied
     });
 
-    expect(global.openApiSpec).toEqual(spec);
-    expect(writeFileSyncSpy).toHaveBeenCalled();
+    expect(generateOpenApiSpecSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ spec })
+    );
 
     if (expectedPathsToBeDenied.length) {
       expect(console.info).toHaveBeenNthCalledWith(
@@ -410,7 +410,9 @@ it('handles error if the OpenAPI spec generation fails', async () => {
     deniedPaths: []
   });
 
-  expect(global.openApiSpec).toEqual(spec);
-  expect(writeFileSyncSpy).toHaveBeenCalled();
+  expect(generateOpenApiSpecSpy).toHaveBeenCalledWith(
+    expect.objectContaining({ spec })
+  );
+
   expectOpenAPIGenerationErrors(error);
 });

--- a/packages/next-rest-framework/tests/pages-router/paths.test.ts
+++ b/packages/next-rest-framework/tests/pages-router/paths.test.ts
@@ -9,7 +9,6 @@ import {
   ValidMethod
 } from '../../src/constants';
 import { z } from 'zod';
-import fs from 'fs';
 import chalk from 'chalk';
 import * as openApiUtils from '../../src/utils/open-api';
 import {
@@ -35,9 +34,7 @@ jest.mock('fs', () => ({
   existsSync: () => true
 }));
 
-const writeFileSyncSpy = jest
-  .spyOn(fs, 'writeFileSync')
-  .mockImplementation(() => {});
+const generateOpenApiSpecSpy = jest.spyOn(openApiUtils, 'generateOpenApiSpec');
 
 jest.mock('path', () => ({
   ...jest.requireActual('path'),
@@ -199,8 +196,9 @@ it('auto-generates the paths from the internal endpoint responses', async () => 
     deniedPaths: []
   });
 
-  expect(global.openApiSpec).toEqual(spec);
-  expect(writeFileSyncSpy).toHaveBeenCalled();
+  expect(generateOpenApiSpecSpy).toHaveBeenCalledWith(
+    expect.objectContaining({ spec })
+  );
 });
 
 it.each([
@@ -271,8 +269,9 @@ it.each([
       deniedPaths: expectedPathsToBeDenied
     });
 
-    expect(global.openApiSpec).toEqual(spec);
-    expect(writeFileSyncSpy).toHaveBeenCalled();
+    expect(generateOpenApiSpecSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ spec })
+    );
 
     if (expectedPathsToBeDenied.length) {
       expect(console.info).toHaveBeenNthCalledWith(
@@ -359,8 +358,9 @@ it.each([
       deniedPaths: expectedPathsToBeDenied
     });
 
-    expect(global.openApiSpec).toEqual(spec);
-    expect(writeFileSyncSpy).toHaveBeenCalled();
+    expect(generateOpenApiSpecSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ spec })
+    );
 
     if (expectedPathsToBeDenied.length) {
       expect(console.info).toHaveBeenNthCalledWith(
@@ -406,7 +406,8 @@ it('handles error if the OpenAPI spec generation fails', async () => {
     deniedPaths: []
   });
 
-  expect(global.openApiSpec).toEqual(spec);
-  expect(writeFileSyncSpy).toHaveBeenCalled();
+  expect(generateOpenApiSpecSpy).toHaveBeenCalledWith(
+    expect.objectContaining({ spec })
+  );
   expectOpenAPIGenerationErrors(error);
 });

--- a/packages/next-rest-framework/tests/utils.ts
+++ b/packages/next-rest-framework/tests/utils.ts
@@ -20,9 +20,6 @@ import { type BaseQuery, type Modify } from '../src/types';
 
 export const resetCustomGlobals = () => {
   global.nextRestFrameworkConfig = undefined;
-  global.openApiSpec = undefined;
-  global.apiSpecGeneratedLogged = false;
-  global.ignoredPathsLogged = false;
 };
 
 export const createMockRouteRequest = <Body, Query>({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -80,6 +80,7 @@ importers:
       lodash: 4.17.21
       node-mocks-http: 1.13.0
       openapi-types: 12.1.3
+      prettier: 3.0.2
       ts-jest: 29.1.1
       ts-node: 10.9.1
       typescript: '*'
@@ -89,6 +90,7 @@ importers:
       chalk: 4.1.2
       commander: 10.0.1
       lodash: 4.17.21
+      prettier: 3.0.2
       wait-on: 7.0.1
       zod-to-json-schema: 3.21.4_zod@3.22.2
     devDependencies:
@@ -8963,7 +8965,6 @@ packages:
     resolution: {integrity: sha512-o2YR9qtniXvwEZlOKbveKfDQVyqxbEIWn48Z8m3ZJjBjcCmUy3xZGIv+7AkaeuaTr6yPXJjwv07ZWlsWbEy1rQ==}
     engines: {node: '>=14'}
     hasBin: true
-    dev: true
 
   /pretty-error/4.0.0:
     resolution: {integrity: sha512-AoJ5YMAcXKYxKhuJGdcvse+Voc6v1RgnsR3nWcYU7q4t6z0Q6T86sv5Zq8VIRbOWWFpvdGE83LtdSMNd+6Y0xw==}


### PR DESCRIPTION
This improves the CLI performance, makes
it supported in any runtime and adds a new
`next-rest-framework validate` command, that
checks that the generated `openapi.json` file
is up to date. The CLI commands no longer
spin up the Next.js dev server, but instead
optionally run `next build` to generate the
routes and generates the OpenAPI paths from
those generated routes.