### PR TITLE
Fix request handling with proxies

### DIFF
--- a/packages/next-rest-framework/src/docs-handlers.ts
+++ b/packages/next-rest-framework/src/docs-handlers.ts
@@ -45,7 +45,32 @@ export const docsRouteHandler = (_config?: NextRestFrameworkConfig) => {
 
   const handler = async (req: NextRequest, _context: { params: BaseQuery }) => {
     try {
-      const { headers, url } = req;
+      const { headers, nextUrl } = req;
+
+      const proto = headers.get('x-forwarded-proto');
+
+      if (!proto) {
+        return NextResponse.json(
+          {
+            message: 'The request is missing `x-forwarded-proto` header.'
+          },
+          { status: 401 }
+        );
+      }
+
+      const host = headers.get('host');
+
+      if (!host) {
+        return NextResponse.json(
+          {
+            message: 'The request is missing `host` header.'
+          },
+          { status: 401 }
+        );
+      }
+
+      const baseUrl = `${proto}://${host}`;
+      const url = baseUrl + nextUrl.pathname;
 
       // Return 403 if called internally by the framework.
       if (headers.get('user-agent') === NEXT_REST_FRAMEWORK_USER_AGENT) {
@@ -56,10 +81,6 @@ export const docsRouteHandler = (_config?: NextRestFrameworkConfig) => {
           { status: 403 }
         );
       }
-
-      const proto = new URL(url).protocol;
-      const host = headers.get('host');
-      const baseUrl = `${proto}//${host}`;
 
       if (!config.suppressInfo) {
         logInitInfo({ config, baseUrl, url });
@@ -109,13 +130,28 @@ export const docsApiRouteHandler = (_config?: NextRestFrameworkConfig) => {
         return;
       }
 
-      const _proto = req.headers['x-forwarded-proto'];
+      const proto = req.headers['x-forwarded-proto'];
 
-      const proto = Array.isArray(_proto)
-        ? _proto[0]
-        : _proto?.split(',')[0] ?? 'http';
+      if (!proto) {
+        return NextResponse.json(
+          {
+            message: 'The request is missing `x-forwarded-proto` header.'
+          },
+          { status: 401 }
+        );
+      }
 
       const host = req.headers.host;
+
+      if (!host) {
+        return NextResponse.json(
+          {
+            message: 'The request is missing `host` header.'
+          },
+          { status: 401 }
+        );
+      }
+
       const baseUrl = `${proto}://${host}`;
       const url = baseUrl + req.url;
 

--- a/packages/next-rest-framework/src/utils/open-api.ts
+++ b/packages/next-rest-framework/src/utils/open-api.ts
@@ -96,6 +96,9 @@ export const generatePathsFromDev = async ({
   baseUrl: string;
   url: string;
 }): Promise<OpenAPIV3_1.PathsObject> => {
+  // Disable TLS certificate validation in development mode to enable local development using HTTPS.
+  process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
+
   const ignoredPaths: string[] = [];
 
   // Check if the route is allowed or denied by the user.
@@ -206,7 +209,7 @@ export const generatePathsFromDev = async ({
             'User-Agent': NEXT_REST_FRAMEWORK_USER_AGENT,
             'Content-Type': 'application/json',
             'x-forwarded-proto': baseUrl.split('://')[0],
-            'x-forwarded-host': baseUrl.split('://')[1]
+            host: baseUrl.split('://')[1]
           },
           signal: controller.signal
         });


### PR DESCRIPTION
This fixes request handling when using
a proxy or HTTPS connections locally.
The request protocol/host parsing is fixed
and validated now similarly on both routers.

Additionally, the TLS certificate validation
is disabled when developing locally.