### PR TITLE
Add support for strongly-typed NextResponse

### DIFF
--- a/packages/next-rest-framework/src/index.ts
+++ b/packages/next-rest-framework/src/index.ts
@@ -5,3 +5,4 @@ export {
   apiRouteOperation
 } from './route-handlers';
 export { docsRouteHandler, docsApiRouteHandler } from './docs-handlers';
+export { TypedNextResponse } from './types';

--- a/packages/next-rest-framework/src/types/index.ts
+++ b/packages/next-rest-framework/src/types/index.ts
@@ -1,4 +1,5 @@
 export * from './config';
 export * from './content-types';
 export * from './route-handlers';
+export * from './typed-next-response';
 export * from './utility-types';

--- a/packages/next-rest-framework/src/types/route-handlers.ts
+++ b/packages/next-rest-framework/src/types/route-handlers.ts
@@ -14,8 +14,9 @@ import { type NextURL } from 'next/dist/server/web/next-url';
 import { type OpenAPIV3_1 } from 'openapi-types';
 import { type AnyContentTypeWithAutocompleteForMostCommonOnes } from './content-types';
 import { type ZodSchema, type z } from 'zod';
+import { type TypedNextResponse } from './typed-next-response';
 
-type BaseStatus = number;
+export type BaseStatus = number;
 type BaseContentType = AnyContentTypeWithAutocompleteForMostCommonOnes;
 export type BaseQuery = Record<string, string | string[]>;
 
@@ -57,8 +58,6 @@ type TypedNextRequest<Body, Query extends BaseQuery> = Modify<
   }
 >;
 
-type TypedNextResponse<Body> = NextResponse<Body>;
-
 type RouteHandler<
   Body = unknown,
   Query extends BaseQuery = BaseQuery,
@@ -67,7 +66,13 @@ type RouteHandler<
   Output extends ReadonlyArray<
     OutputObject<ResponseBody, Status>
   > = ReadonlyArray<OutputObject<ResponseBody, Status>>,
-  TypedResponse = TypedNextResponse<z.infer<Output[number]['schema']>> | void
+  TypedResponse =
+    | TypedNextResponse<
+        z.infer<Output[number]['schema']>,
+        Output[number]['status']
+      >
+    | NextResponse<z.infer<Output[number]['schema']>>
+    | void
 > = (
   req: TypedNextRequest<Body, Query>,
   context: { params: Record<string, string> }

--- a/packages/next-rest-framework/src/types/typed-next-response.ts
+++ b/packages/next-rest-framework/src/types/typed-next-response.ts
@@ -1,0 +1,63 @@
+import { type I18NConfig } from 'next/dist/server/config-shared';
+import { type ResponseCookies } from 'next/dist/server/web/spec-extension/cookies';
+import { type BaseStatus } from './route-handlers';
+import { type NextURL } from 'next/dist/server/web/next-url';
+
+interface TypedResponseInit<Status extends BaseStatus>
+  extends globalThis.ResponseInit {
+  nextConfig?: {
+    basePath?: string;
+    i18n?: I18NConfig;
+    trailingSlash?: boolean;
+  };
+  url?: string;
+  status?: Status;
+}
+
+interface ModifiedRequest {
+  headers?: Headers;
+}
+
+interface TypedMiddlewareResponseInit<Status extends BaseStatus>
+  extends globalThis.ResponseInit {
+  request?: ModifiedRequest;
+  status?: Status;
+}
+
+declare const INTERNALS: unique symbol;
+
+// A patched `NextResponse` that allows to strongly-typed status codes.
+export declare class TypedNextResponse<
+  Body,
+  Status extends BaseStatus
+> extends Response {
+  [INTERNALS]: {
+    cookies: ResponseCookies;
+    url?: NextURL;
+    body?: Body;
+    status?: Status;
+  };
+
+  constructor(body?: BodyInit | null, init?: TypedResponseInit<Status>);
+
+  get cookies(): ResponseCookies;
+
+  static json<JsonBody, StatusCode extends BaseStatus>(
+    body: JsonBody,
+    init?: TypedResponseInit<StatusCode>
+  ): TypedNextResponse<JsonBody, StatusCode>;
+
+  static redirect<StatusCode extends BaseStatus>(
+    url: string | NextURL | URL,
+    init?: number | TypedResponseInit<StatusCode>
+  ): TypedNextResponse<unknown, StatusCode>;
+
+  static rewrite<StatusCode extends BaseStatus>(
+    destination: string | NextURL | URL,
+    init?: TypedMiddlewareResponseInit<StatusCode>
+  ): TypedNextResponse<unknown, StatusCode>;
+
+  static next<StatusCode extends BaseStatus>(
+    init?: TypedMiddlewareResponseInit<StatusCode>
+  ): TypedNextResponse<unknown, StatusCode>;
+}


### PR DESCRIPTION
Previously, the problem with App Router was that
truly strongly-typed responses were not possible due to the `NextResponse` class not supporting a generic typing of the status codes. This change adds a patched `TypedNextResponse` class that adds support for
type-checking the response status codes based on
the output schema.

In order to achieve this, the user must import the `TypedNextResponse` class from Next REST Framework, but the good thing is that this is fully optional and using the plain `NextResponse` is still supported if the user prefers not to have strongly typed status code checks.