### PR TITLE
Remove shebang injection from preinstall

### DIFF
--- a/packages/next-rest-framework/package.json
+++ b/packages/next-rest-framework/package.json
@@ -25,7 +25,6 @@
     "directory": "packages/next-rest-framework"
   },
   "scripts": {
-    "preinstall": "mkdir -p dist && touch ./dist/cli.js && echo \"#!/usr/bin/env node\" > ./dist/cli.js",
     "type-check": "tsc --noEmit",
     "build": "rm -rf dist && tsc --project tsconfig.build.json",
     "test": "node --experimental-vm-modules ./node_modules/jest/bin/jest.js",


### PR DESCRIPTION
The preinstall script that injects the node env
shebang to the dist CLI script is no longer needed as that gets automatically included in the build
output and having that UNIX-specific syntax in
the preinstall script breaks the installation on
Windows.