### PR TITLE
Fix issue with OpenAPI spec generator failing to generate valid paths when more than one path parameter exists 

### DIFF
--- a/packages/next-rest-framework/src/utils/open-api.ts
+++ b/packages/next-rest-framework/src/utils/open-api.ts
@@ -53,15 +53,15 @@ export const getRouteName = (file: string) =>
     .replace('/route.js', '')
     .replace('/route.ts', '')
     .replace(/\\/g, '/')
-    .replace('[', '{')
-    .replace(']', '}');
+    .replaceAll('[', '{')
+    .replaceAll(']', '}');
 
 export const getApiRouteName = (file: string) =>
   `/api/${file}`
     .replace('/index', '')
     .replace(/\\/g, '/')
-    .replace('[', '{')
-    .replace(']', '}')
+    .replaceAll('[', '{')
+    .replaceAll(']', '}')
     .replace('.js', '')
     .replace('.ts', '');
 

--- a/packages/next-rest-framework/tests/app-router/paths.test.ts
+++ b/packages/next-rest-framework/tests/app-router/paths.test.ts
@@ -28,7 +28,8 @@ jest.mock('fs', () => ({
           'api/foo/route.ts',
           'api/foo/bar/route.ts',
           'api/foo/bar/baz/route.ts',
-          'api/foo/bar/[qux]/route.ts'
+          'api/foo/bar/[qux]/route.ts',
+          'api/foo/bar/[qux]/quux/[corge]/route.ts'
         ];
 
     return paths.map(createDirent);
@@ -121,6 +122,20 @@ const fooBarBazQuxMethodHandlers = routeHandler({
     })
 });
 
+const fooBarBazQuxQuuxCorgeMethodHandlers = routeHandler({
+  GET: routeOperation()
+    .output([
+      {
+        status: 200,
+        schema,
+        contentType: 'application/json'
+      }
+    ])
+    .handler(async () => {
+      return NextResponse.json({ foo: 'corge' }, { status: 200 });
+    })
+});
+
 jest.mock(
   '../../../apps/src/dev/app/api/foo/route.ts',
   () => fooMethodHandlers,
@@ -147,6 +162,12 @@ jest.mock(
   { virtual: true }
 );
 
+jest.mock(
+  '../../../apps/src/dev/app/api/foo/bar/[qux]/quux/[corge]/route.ts',
+  () => fooBarBazQuxQuuxCorgeMethodHandlers,
+  { virtual: true }
+);
+
 // @ts-expect-error: TS expects the mock function to extend the typings of the global `fetch` function but we don't need those types here.
 global.fetch = async (url: string) => {
   const path = url.replace('http://localhost:3000', '');
@@ -166,7 +187,8 @@ global.fetch = async (url: string) => {
     '/api/foo': fooMethodHandlers,
     '/api/foo/bar': fooBarMethodHandlers,
     '/api/foo/bar/baz': fooBarBazMethodHandlers,
-    '/api/foo/bar/{qux}': fooBarBazQuxMethodHandlers
+    '/api/foo/bar/{qux}': fooBarBazQuxMethodHandlers,
+    '/api/foo/bar/{qux}/quux/{corge}': fooBarBazQuxQuuxCorgeMethodHandlers
   };
 
   const methodHandlers =
@@ -195,7 +217,8 @@ it('auto-generates the paths from the internal endpoint responses', async () => 
       '/api/foo',
       '/api/foo/bar',
       '/api/foo/bar/baz',
-      '/api/foo/bar/{qux}'
+      '/api/foo/bar/{qux}',
+      '/api/foo/bar/{qux}/quux/{corge}'
     ],
     deniedPaths: []
   });
@@ -213,7 +236,8 @@ it.each([
       '/api/foo',
       '/api/foo/bar',
       '/api/foo/bar/baz',
-      '/api/foo/bar/{qux}'
+      '/api/foo/bar/{qux}',
+      '/api/foo/bar/{qux}/quux/{corge}'
     ]
   },
   {
@@ -222,7 +246,8 @@ it.each([
       '/api/foo',
       '/api/foo/bar',
       '/api/foo/bar/baz',
-      '/api/foo/bar/{qux}'
+      '/api/foo/bar/{qux}',
+      '/api/foo/bar/{qux}/quux/{corge}'
     ],
     expectedPathsToBeDenied: []
   },
@@ -232,20 +257,27 @@ it.each([
     expectedPathsToBeDenied: [
       '/api/foo/bar',
       '/api/foo/bar/baz',
-      '/api/foo/bar/{qux}'
+      '/api/foo/bar/{qux}',
+      '/api/foo/bar/{qux}/quux/{corge}'
     ]
   },
   {
     allowedPaths: ['/api/foo/*/baz'],
     expectedPathsToBeAllowed: ['/api/foo/bar/baz'],
-    expectedPathsToBeDenied: ['/api/foo', '/api/foo/bar', '/api/foo/bar/{qux}']
+    expectedPathsToBeDenied: [
+      '/api/foo',
+      '/api/foo/bar',
+      '/api/foo/bar/{qux}',
+      '/api/foo/bar/{qux}/quux/{corge}'
+    ]
   },
   {
     allowedPaths: ['/api/foo/**'],
     expectedPathsToBeAllowed: [
       '/api/foo/bar',
       '/api/foo/bar/baz',
-      '/api/foo/bar/{qux}'
+      '/api/foo/bar/{qux}',
+      '/api/foo/bar/{qux}/quux/{corge}'
     ],
     expectedPathsToBeDenied: ['/api/foo']
   }
@@ -297,7 +329,8 @@ it.each([
       '/api/foo',
       '/api/foo/bar',
       '/api/foo/bar/baz',
-      '/api/foo/bar/{qux}'
+      '/api/foo/bar/{qux}',
+      '/api/foo/bar/{qux}/quux/{corge}'
     ],
     expectedPathsToBeDenied: []
   },
@@ -308,7 +341,8 @@ it.each([
       '/api/foo',
       '/api/foo/bar',
       '/api/foo/bar/baz',
-      '/api/foo/bar/{qux}'
+      '/api/foo/bar/{qux}',
+      '/api/foo/bar/{qux}/quux/{corge}'
     ]
   },
   {
@@ -316,7 +350,8 @@ it.each([
     expectedPathsToBeAllowed: [
       '/api/foo/bar',
       '/api/foo/bar/baz',
-      '/api/foo/bar/{qux}'
+      '/api/foo/bar/{qux}',
+      '/api/foo/bar/{qux}/quux/{corge}'
     ],
     expectedPathsToBeDenied: ['/api/foo']
   },
@@ -325,7 +360,8 @@ it.each([
     expectedPathsToBeAllowed: [
       '/api/foo',
       '/api/foo/bar',
-      '/api/foo/bar/{qux}'
+      '/api/foo/bar/{qux}',
+      '/api/foo/bar/{qux}/quux/{corge}'
     ],
     expectedPathsToBeDenied: ['/api/foo/bar/baz']
   },
@@ -335,7 +371,8 @@ it.each([
     expectedPathsToBeDenied: [
       '/api/foo/bar',
       '/api/foo/bar/baz',
-      '/api/foo/bar/{qux}'
+      '/api/foo/bar/{qux}',
+      '/api/foo/bar/{qux}/quux/{corge}'
     ]
   }
 ])(

--- a/packages/next-rest-framework/tests/utils.ts
+++ b/packages/next-rest-framework/tests/utils.ts
@@ -189,6 +189,35 @@ export const getExpectedSpec = ({
     };
   }
 
+  if (
+    !deniedPaths.includes('/api/foo/bar/{qux}/quux/{corge}') &&
+    allowedPaths.includes('/api/foo/bar/{qux}/quux/{corge}')
+  ) {
+    paths = {
+      ...paths,
+      '/api/foo/bar/{qux}/quux/{corge}': {
+        get: {
+          parameters: [
+            {
+              in: 'path',
+              name: 'qux',
+              required: true
+            },
+            {
+              in: 'path',
+              name: 'corge',
+              required: true
+            }
+          ],
+          responses: {
+            '200': responseContent,
+            default: defaultResponse
+          }
+        }
+      }
+    };
+  }
+
   const spec = {
     openapi: OPEN_API_VERSION,
     info: {
@@ -228,6 +257,13 @@ ${`Error: ${error}`}`)
     4,
     chalk.red(`Next REST Framework encountered an error:
 ${'Error: OpenAPI spec generation failed for route: /api/foo/bar/{qux}'}
+${`Error: ${error}`}`)
+  );
+
+  expect(console.error).toHaveBeenNthCalledWith(
+    5,
+    chalk.red(`Next REST Framework encountered an error:
+${'Error: OpenAPI spec generation failed for route: /api/foo/bar/{qux}/quux/{corge}'}
 ${`Error: ${error}`}`)
   );
 };


### PR DESCRIPTION
This fixes #96.