### PR TITLE
Use content-relative URL for fetching `openapi.json` in docs

### DIFF
--- a/packages/next-rest-framework/src/docs-handlers.ts
+++ b/packages/next-rest-framework/src/docs-handlers.ts
@@ -47,7 +47,7 @@ export const docsRouteHandler = (_config?: NextRestFrameworkConfig) => {
     try {
       const { headers, nextUrl } = req;
       const proto = headers.get('x-forwarded-proto') ?? 'http';
-      const host = headers.get('host');
+      const host = headers.get('host') ?? '';
       const baseUrl = `${proto}://${host}`;
       const url = baseUrl + nextUrl.pathname;
 
@@ -73,7 +73,7 @@ export const docsRouteHandler = (_config?: NextRestFrameworkConfig) => {
         await syncOpenApiSpec({ config, paths });
       }
 
-      const html = getHtmlForDocs({ config, baseUrl });
+      const html = getHtmlForDocs({ config, host });
 
       return new NextResponse(html, {
         headers: {
@@ -110,7 +110,7 @@ export const docsApiRouteHandler = (_config?: NextRestFrameworkConfig) => {
       }
 
       const proto = req.headers['x-forwarded-proto'] ?? 'http';
-      const host = req.headers.host;
+      const host = req.headers.host ?? '';
       const baseUrl = `${proto}://${host}`;
       const url = baseUrl + req.url;
 
@@ -126,10 +126,7 @@ export const docsApiRouteHandler = (_config?: NextRestFrameworkConfig) => {
         await syncOpenApiSpec({ config, paths });
       }
 
-      const html = getHtmlForDocs({
-        config,
-        baseUrl
-      });
+      const html = getHtmlForDocs({ config, host });
 
       res.setHeader('Content-Type', 'text/html');
       res.status(200).send(html);

--- a/packages/next-rest-framework/src/utils/docs.ts
+++ b/packages/next-rest-framework/src/utils/docs.ts
@@ -18,12 +18,12 @@ export const getHtmlForDocs = ({
       logoUrl = DEFAULT_LOGO_URL
     }
   },
-  baseUrl
+  host
 }: {
   config: Required<NextRestFrameworkConfig>;
-  baseUrl: string;
+  host: string;
 }) => {
-  const url = `${baseUrl}${openApiJsonPath}`;
+  const url = `//${host}${openApiJsonPath}`; // Use protocol-relative URL to avoid mixed content warnings.
 
   const redocHtml = `<!DOCTYPE html>
 <html>

--- a/packages/next-rest-framework/tests/app-router/index.test.ts
+++ b/packages/next-rest-framework/tests/app-router/index.test.ts
@@ -154,7 +154,7 @@ it.each(['redoc', 'swagger-ui'] satisfies DocsProvider[])(
 
     const html = getHtmlForDocs({
       config: getConfig(_config),
-      baseUrl: 'http://localhost:3000'
+      host: 'localhost:3000'
     });
 
     expect(text).toEqual(html);

--- a/packages/next-rest-framework/tests/pages-router/index.test.ts
+++ b/packages/next-rest-framework/tests/pages-router/index.test.ts
@@ -151,7 +151,7 @@ it.each(['redoc', 'swagger-ui'] satisfies DocsProvider[])(
 
     const html = getHtmlForDocs({
       config: getConfig(_config),
-      baseUrl: 'http://localhost:3000'
+      host: 'localhost:3000'
     });
 
     expect(text).toEqual(html);


### PR DESCRIPTION
For HTTP production environments that are not configured to use the `x-forwarded-proto` header, the API docs will default the fetch the `openapi.json` over plain HTTP, leading to mixed content errors. This change uses content-relative URL to fetch the `openapi.json`, which defaults to the currently used protocol.