### PR TITLE
Update prettier import syntax

### DIFF
--- a/packages/next-rest-framework/src/utils/open-api.ts
+++ b/packages/next-rest-framework/src/utils/open-api.ts
@@ -15,7 +15,7 @@ import { merge, isEqualWith } from 'lodash';
 import { getJsonSchema, getSchemaKeys } from './schemas';
 import { existsSync, readdirSync, readFileSync, writeFileSync } from 'fs';
 import chalk from 'chalk';
-import prettier from 'prettier';
+import * as prettier from 'prettier';
 
 // Traverse the base path and find all nested files.
 export const getNestedFiles = (basePath: string, dir: string): string[] => {


### PR DESCRIPTION
This fix imports all named prettier exports
as a single module according to the prettier
API documentation: https://prettier.io/docs/en/api.html

This is a potential fix for a module resolution issue that causes a crash in some environments where
the default import causes "module" not being found.