### PR TITLE
Improve OpenAPI generation

### DIFF
--- a/apps/example/public/openapi.json
+++ b/apps/example/public/openapi.json
@@ -10,32 +10,20 @@
       "get": {
         "responses": {
           "200": {
+            "description": "Response for status 200",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "id": { "type": "number" },
-                      "name": { "type": "string" },
-                      "completed": { "type": "boolean" }
-                    },
-                    "required": ["id", "name", "completed"],
-                    "additionalProperties": false
-                  }
+                  "$ref": "#/components/schemas/GetTodosResponseBody"
                 }
               }
             }
           },
-          "default": {
+          "500": {
             "description": "An unknown error occurred, trying again might help.",
             "content": {
               "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": { "message": { "type": "string" } }
-                }
+                "schema": { "$ref": "#/components/schemas/UnexpectedError" }
               }
             }
           }
@@ -47,34 +35,36 @@
         "requestBody": {
           "content": {
             "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": { "name": { "type": "string" } },
-                "required": ["name"],
-                "additionalProperties": false
-              }
+              "schema": { "$ref": "#/components/schemas/PostTodosRequestBody" }
             }
           }
         },
         "responses": {
           "201": {
-            "content": {
-              "application/json": { "schema": { "type": "string" } }
-            }
-          },
-          "401": {
-            "content": {
-              "application/json": { "schema": { "type": "string" } }
-            }
-          },
-          "default": {
-            "description": "An unknown error occurred, trying again might help.",
+            "description": "Response for status 201",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": { "message": { "type": "string" } }
+                  "$ref": "#/components/schemas/PostTodosResponseBody"
                 }
+              }
+            }
+          },
+          "401": {
+            "description": "Response for status 401",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PostTodosErrorResponseBody"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An unknown error occurred, trying again might help.",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/UnexpectedError" }
               }
             }
           }
@@ -87,67 +77,84 @@
       "get": {
         "responses": {
           "200": {
+            "description": "Response for status 200",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "id": { "type": "number" },
-                    "name": { "type": "string" },
-                    "completed": { "type": "boolean" }
-                  },
-                  "required": ["id", "name", "completed"],
-                  "additionalProperties": false
+                  "$ref": "#/components/schemas/GetTodosResponseBody"
                 }
               }
             }
           },
           "404": {
-            "content": {
-              "application/json": { "schema": { "type": "string" } }
-            }
-          },
-          "default": {
-            "description": "An unknown error occurred, trying again might help.",
+            "description": "Response for status 404",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": { "message": { "type": "string" } }
+                  "$ref": "#/components/schemas/GetTodosErrorResponseBody"
                 }
+              }
+            }
+          },
+          "500": {
+            "description": "An unknown error occurred, trying again might help.",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/UnexpectedError" }
               }
             }
           }
         },
-        "parameters": [{ "name": "id", "in": "path", "required": true }],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
         "operationId": "getTodoById",
         "tags": ["example-api", "todos", "pages-router"]
       },
       "delete": {
         "responses": {
           "204": {
-            "content": {
-              "application/json": { "schema": { "type": "string" } }
-            }
-          },
-          "404": {
-            "content": {
-              "application/json": { "schema": { "type": "string" } }
-            }
-          },
-          "default": {
-            "description": "An unknown error occurred, trying again might help.",
+            "description": "Response for status 204",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": { "message": { "type": "string" } }
+                  "$ref": "#/components/schemas/DeleteTodosResponseBody"
                 }
+              }
+            }
+          },
+          "404": {
+            "description": "Response for status 404",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DeleteTodosErrorResponseBody"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An unknown error occurred, trying again might help.",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/UnexpectedError" }
               }
             }
           }
         },
-        "parameters": [{ "name": "id", "in": "path", "required": true }],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
         "operationId": "deleteTodo",
         "tags": ["example-api", "todos", "pages-router"]
       }
@@ -179,9 +186,9 @@
                   }
                 },
                 "oneOf": [
-                  "#/components/schemas/GetTodoByIdBody",
-                  "#/components/schemas/CreateTodoBody",
-                  "#/components/schemas/DeleteTodoBody"
+                  { "$ref": "#/components/schemas/GetTodoByIdBody" },
+                  { "$ref": "#/components/schemas/CreateTodoBody" },
+                  { "$ref": "#/components/schemas/DeleteTodoBody" }
                 ]
               }
             }
@@ -202,25 +209,22 @@
                     }
                   },
                   "oneOf": [
-                    "#/components/schemas/GetTodosResponse",
-                    "#/components/schemas/GetTodoByIdResponse",
-                    "#/components/schemas/GetTodoByIdResponse2",
-                    "#/components/schemas/CreateTodoResponse",
-                    "#/components/schemas/DeleteTodoResponse",
-                    "#/components/schemas/DeleteTodoResponse2"
+                    { "$ref": "#/components/schemas/GetTodosResponse" },
+                    { "$ref": "#/components/schemas/GetTodoByIdResponse" },
+                    { "$ref": "#/components/schemas/GetTodoByIdResponse2" },
+                    { "$ref": "#/components/schemas/CreateTodoResponse" },
+                    { "$ref": "#/components/schemas/DeleteTodoResponse" },
+                    { "$ref": "#/components/schemas/DeleteTodoResponse2" }
                   ]
                 }
               }
             }
           },
-          "default": {
+          "500": {
             "description": "An unknown error occurred, trying again might help.",
             "content": {
               "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": { "message": { "type": "string" } }
-                }
+                "schema": { "$ref": "#/components/schemas/UnexpectedError" }
               }
             }
           }
@@ -231,32 +235,20 @@
       "get": {
         "responses": {
           "200": {
+            "description": "Response for status 200",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "id": { "type": "number" },
-                      "name": { "type": "string" },
-                      "completed": { "type": "boolean" }
-                    },
-                    "required": ["id", "name", "completed"],
-                    "additionalProperties": false
-                  }
+                  "$ref": "#/components/schemas/GetTodosResponseBody"
                 }
               }
             }
           },
-          "default": {
+          "500": {
             "description": "An unknown error occurred, trying again might help.",
             "content": {
               "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": { "message": { "type": "string" } }
-                }
+                "schema": { "$ref": "#/components/schemas/UnexpectedError" }
               }
             }
           }
@@ -268,34 +260,36 @@
         "requestBody": {
           "content": {
             "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": { "name": { "type": "string" } },
-                "required": ["name"],
-                "additionalProperties": false
-              }
+              "schema": { "$ref": "#/components/schemas/PostTodosRequestBody" }
             }
           }
         },
         "responses": {
           "201": {
-            "content": {
-              "application/json": { "schema": { "type": "string" } }
-            }
-          },
-          "401": {
-            "content": {
-              "application/json": { "schema": { "type": "string" } }
-            }
-          },
-          "default": {
-            "description": "An unknown error occurred, trying again might help.",
+            "description": "Response for status 201",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": { "message": { "type": "string" } }
+                  "$ref": "#/components/schemas/CreateTodoSuccessResponse"
                 }
+              }
+            }
+          },
+          "401": {
+            "description": "Response for status 401",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CreateTodoUnauthorizedResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An unknown error occurred, trying again might help.",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/UnexpectedError" }
               }
             }
           }
@@ -308,67 +302,84 @@
       "get": {
         "responses": {
           "200": {
+            "description": "Response for status 200",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "id": { "type": "number" },
-                    "name": { "type": "string" },
-                    "completed": { "type": "boolean" }
-                  },
-                  "required": ["id", "name", "completed"],
-                  "additionalProperties": false
+                  "$ref": "#/components/schemas/GetTodosResponseBody"
                 }
               }
             }
           },
           "404": {
-            "content": {
-              "application/json": { "schema": { "type": "string" } }
-            }
-          },
-          "default": {
-            "description": "An unknown error occurred, trying again might help.",
+            "description": "Response for status 404",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": { "message": { "type": "string" } }
+                  "$ref": "#/components/schemas/GetTodosErrorResponseBody"
                 }
+              }
+            }
+          },
+          "500": {
+            "description": "An unknown error occurred, trying again might help.",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/UnexpectedError" }
               }
             }
           }
         },
-        "parameters": [{ "name": "id", "in": "path", "required": true }],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
         "operationId": "getTodoById",
         "tags": ["example-api", "todos", "app-router"]
       },
       "delete": {
         "responses": {
           "204": {
-            "content": {
-              "application/json": { "schema": { "type": "string" } }
-            }
-          },
-          "404": {
-            "content": {
-              "application/json": { "schema": { "type": "string" } }
-            }
-          },
-          "default": {
-            "description": "An unknown error occurred, trying again might help.",
+            "description": "Response for status 204",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": { "message": { "type": "string" } }
+                  "$ref": "#/components/schemas/DeleteTodosResponseBody"
                 }
+              }
+            }
+          },
+          "404": {
+            "description": "Response for status 404",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DeleteTodosErrorResponseBody"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An unknown error occurred, trying again might help.",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/UnexpectedError" }
               }
             }
           }
         },
-        "parameters": [{ "name": "id", "in": "path", "required": true }],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
         "operationId": "deleteTodo",
         "tags": ["example-api", "todos", "app-router"]
       }
@@ -388,6 +399,8 @@
         "required": ["message"],
         "additionalProperties": false
       },
+      "CreateTodoSuccessResponse": { "type": "string" },
+      "CreateTodoUnauthorizedResponse": { "type": "string" },
       "DeleteTodoBody": { "type": "string" },
       "DeleteTodoResponse": {
         "type": "object",
@@ -401,6 +414,8 @@
         "required": ["message"],
         "additionalProperties": false
       },
+      "DeleteTodosErrorResponseBody": { "type": "string" },
+      "DeleteTodosResponseBody": { "type": "string" },
       "GetTodoByIdBody": { "type": "string" },
       "GetTodoByIdResponse": {
         "type": "object",
@@ -418,6 +433,7 @@
         "required": ["id", "name", "completed"],
         "additionalProperties": false
       },
+      "GetTodosErrorResponseBody": { "type": "string" },
       "GetTodosResponse": {
         "type": "array",
         "items": {
@@ -430,6 +446,29 @@
           "required": ["id", "name", "completed"],
           "additionalProperties": false
         }
+      },
+      "GetTodosResponseBody": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "number" },
+          "name": { "type": "string" },
+          "completed": { "type": "boolean" }
+        },
+        "required": ["id", "name", "completed"],
+        "additionalProperties": false
+      },
+      "PostTodosErrorResponseBody": { "type": "string" },
+      "PostTodosRequestBody": {
+        "type": "object",
+        "properties": { "name": { "type": "string" } },
+        "required": ["name"],
+        "additionalProperties": false
+      },
+      "PostTodosResponseBody": { "type": "string" },
+      "UnexpectedError": {
+        "type": "object",
+        "properties": { "message": { "type": "string" } },
+        "additionalProperties": false
       }
     }
   }

--- a/apps/example/src/app/api/routes/rpc/route.ts
+++ b/apps/example/src/app/api/routes/rpc/route.ts
@@ -11,40 +11,39 @@ const TODOS = [
 
 // Example App Router RPC handler.
 export const POST = rpcRouteHandler({
-  getTodos: rpcOperation({
-    // Optional OpenAPI operation documentation.
-    operationId: 'getTodos',
-    tags: ['example-api', 'todos', 'app-router', 'rpc']
-  })
+  getTodos: rpcOperation()
     // Output schema for strictly-typed responses and OpenAPI documentation.
     .output([
-      z.array(
-        z.object({
-          id: z.number(),
-          name: z.string(),
-          completed: z.boolean()
-        })
-      )
+      {
+        schema: z.array(
+          z.object({
+            id: z.number(),
+            name: z.string(),
+            completed: z.boolean()
+          })
+        )
+      }
     ])
     .handler(() => {
       // Type-checked response.
       return TODOS;
     }),
 
-  getTodoById: rpcOperation({
-    operationId: 'getTodoById',
-    tags: ['example-api', 'todos', 'app-router', 'rpc']
-  })
+  getTodoById: rpcOperation()
     .input(z.string())
     .output([
-      z.object({
-        error: z.string()
-      }),
-      z.object({
-        id: z.number(),
-        name: z.string(),
-        completed: z.boolean()
-      })
+      {
+        schema: z.object({
+          error: z.string()
+        })
+      },
+      {
+        schema: z.object({
+          id: z.number(),
+          name: z.string(),
+          completed: z.boolean()
+        })
+      }
     ])
     .handler((id) => {
       const todo = TODOS.find((t) => t.id === Number(id));
@@ -58,11 +57,7 @@ export const POST = rpcRouteHandler({
       return todo;
     }),
 
-  createTodo: rpcOperation({
-    // Optional OpenAPI operation documentation.
-    operationId: 'createTodo',
-    tags: ['example-api', 'todos', 'app-router', 'rpc']
-  })
+  createTodo: rpcOperation()
     // Input schema for strictly-typed request, request validation and OpenAPI documentation.
     .input(
       z.object({
@@ -70,20 +65,17 @@ export const POST = rpcRouteHandler({
       })
     )
     // Output schema for strictly-typed responses and OpenAPI documentation.
-    .output([z.object({ message: z.string() })])
+    .output([{ schema: z.object({ message: z.string() }) }])
     .handler(async ({ name }) => {
       // Type-checked response.
       return { message: `New TODO created: ${name}` };
     }),
 
-  deleteTodo: rpcOperation({
-    operationId: 'deleteTodo',
-    tags: ['example-api', 'todos', 'app-router', 'rpc']
-  })
+  deleteTodo: rpcOperation()
     .input(z.string())
     .output([
-      z.object({ error: z.string() }),
-      z.object({ message: z.string() })
+      { schema: z.object({ error: z.string() }) },
+      { schema: z.object({ message: z.string() }) }
     ])
     .handler((id) => {
       // Delete todo.

--- a/apps/example/src/app/api/routes/todos/route.ts
+++ b/apps/example/src/app/api/routes/todos/route.ts
@@ -58,12 +58,14 @@ const handler = routeHandler({
       {
         status: 201,
         contentType: 'application/json',
-        schema: z.string()
+        schema: z.string(),
+        name: 'CreateTodoSuccessResponse' // Optional name for OpenAPI spec.
       },
       {
         status: 401,
         contentType: 'application/json',
-        schema: z.string()
+        schema: z.string(),
+        name: 'CreateTodoUnauthorizedResponse' // Optional name for OpenAPI spec.
       }
     ])
     // Optional middleware logic executed before request validation.

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "test:watch": "pnpm --filter next-rest-framework run test:watch",
     "type-check": "pnpm run -r type-check",
     "format": "prettier --write '**/*.{ts,json}' && eslint --fix --max-warnings=0 --ext=.ts .",
-    "lint": "prettier --check '**/*.{ts,json}' && eslint --max-warnings=0 --ext=.ts .",
+    "lint": "prettier --check '**/*.{ts,json}' && eslint --max-warnings=0 --ext=.ts . && swagger-cli validate ./apps/example/public/openapi.json",
     "ci": "pnpm run build && pnpm run type-check && pnpm run lint && pnpm run test"
   },
   "dependencies": {
@@ -16,6 +16,7 @@
     "react-dom": "18.2.0"
   },
   "devDependencies": {
+    "@apidevtools/swagger-cli": "4.0.4",
     "@types/node": "20.5.4",
     "@types/react": "18.2.21",
     "@types/react-dom": "18.2.7",

--- a/packages/next-rest-framework/src/app-router/route-handler.ts
+++ b/packages/next-rest-framework/src/app-router/route-handler.ts
@@ -1,8 +1,8 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { DEFAULT_ERRORS, NEXT_REST_FRAMEWORK_USER_AGENT } from '../constants';
-import { type BaseQuery } from '../types';
+import { type OpenApiPathItem, type BaseQuery } from '../types';
 import {
-  getPathsFromMethodHandlers,
+  getOasDataFromMethodHandlers,
   isValidMethod,
   validateSchema,
   logNextRestFrameworkError
@@ -10,12 +10,10 @@ import {
 
 import { type ValidMethod } from '../constants';
 
-import { type OpenAPIV3_1 } from 'openapi-types';
-
 import { type RouteOperationDefinition } from './route-operation';
 
 export interface RouteParams {
-  openApiPath?: OpenAPIV3_1.PathItemObject;
+  openApiPath?: OpenApiPathItem;
   [ValidMethod.GET]?: RouteOperationDefinition;
   [ValidMethod.PUT]?: RouteOperationDefinition;
   [ValidMethod.POST]?: RouteOperationDefinition;
@@ -54,7 +52,7 @@ export const routeHandler = (methodHandlers: RouteParams) => {
         const route = decodeURIComponent(pathname ?? '');
 
         try {
-          const nrfOasData = getPathsFromMethodHandlers({
+          const nrfOasData = getOasDataFromMethodHandlers({
             methodHandlers,
             route
           });
@@ -72,7 +70,7 @@ ${error}`);
         return handleMethodNotAllowed();
       }
 
-      const { input, handler, middleware } = methodHandler._config;
+      const { input, handler, middleware } = methodHandler._meta;
 
       if (middleware) {
         const res = await middleware(new NextRequest(req.clone()), context);
@@ -163,7 +161,7 @@ ${error}`);
   };
 
   handler.getPaths = (route: string) =>
-    getPathsFromMethodHandlers({
+    getOasDataFromMethodHandlers({
       methodHandlers,
       route
     });

--- a/packages/next-rest-framework/src/app-router/route-operation.ts
+++ b/packages/next-rest-framework/src/app-router/route-operation.ts
@@ -1,6 +1,5 @@
 /* eslint-disable @typescript-eslint/no-invalid-void-type */
 
-import { type OpenAPIV3_1 } from 'openapi-types';
 import {
   type BaseStatus,
   type BaseQuery,
@@ -8,7 +7,8 @@ import {
   type OutputObject,
   type BaseContentType,
   type Modify,
-  type AnyCase
+  type AnyCase,
+  type OpenApiOperation
 } from '../types';
 import { type NextRequest, type NextResponse } from 'next/server';
 import { type z } from 'zod';
@@ -216,8 +216,8 @@ type NextRouteHandler = (
 ) => Promise<NextResponse> | NextResponse | Promise<void> | void;
 
 export interface RouteOperationDefinition {
-  _config: {
-    openApiOperation?: OpenAPIV3_1.OperationObject;
+  _meta: {
+    openApiOperation?: OpenApiOperation;
     input?: InputObject;
     output?: readonly OutputObject[];
     middleware?: NextRouteHandler;
@@ -225,7 +225,7 @@ export interface RouteOperationDefinition {
   };
 }
 
-type RouteOperation = (openApiOperation?: OpenAPIV3_1.OperationObject) => {
+type RouteOperation = (openApiOperation?: OpenApiOperation) => {
   input: RouteInput<true>;
   output: RouteOutput<true>;
   middleware: (middleware?: RouteHandler) => {
@@ -241,7 +241,7 @@ export const routeOperation: RouteOperation = (openApiOperation) => {
     middleware: Middleware | undefined,
     handler: Handler | undefined
   ): RouteOperationDefinition => ({
-    _config: {
+    _meta: {
       openApiOperation,
       input,
       output,

--- a/packages/next-rest-framework/src/app-router/rpc-route-handler.ts
+++ b/packages/next-rest-framework/src/app-router/rpc-route-handler.ts
@@ -11,11 +11,16 @@ import {
 } from '../shared';
 import { type Client } from '../client/rpc-client';
 import { type OperationDefinition } from '../shared/rpc-operation';
+import { type OpenApiOperation, type OpenApiPathItem } from '../types';
 
 export const rpcRouteHandler = <
   T extends Record<string, OperationDefinition<any, any>>
 >(
-  operations: T
+  operations: T,
+  options?: {
+    openApiPath?: OpenApiPathItem;
+    openApiOperation?: OpenApiOperation;
+  }
 ) => {
   const handler = async (req: NextRequest) => {
     try {
@@ -43,7 +48,8 @@ export const rpcRouteHandler = <
         try {
           const nrfOasData = getOasDataFromRpcOperations({
             operations,
-            route
+            route,
+            options
           });
 
           return NextResponse.json({ nrfOasData }, { status: 200 });
@@ -136,6 +142,7 @@ ${error}`);
   handler.getPaths = (route: string) =>
     getOasDataFromRpcOperations({
       operations,
+      options,
       route
     });
 

--- a/packages/next-rest-framework/src/pages-router/api-route-handler.ts
+++ b/packages/next-rest-framework/src/pages-router/api-route-handler.ts
@@ -4,17 +4,17 @@ import {
   type ValidMethod
 } from '../constants';
 import {
-  getPathsFromMethodHandlers,
+  getOasDataFromMethodHandlers,
   isValidMethod,
   validateSchema,
   logNextRestFrameworkError
 } from '../shared';
 import { type NextApiRequest, type NextApiResponse } from 'next/types';
-import { type OpenAPIV3_1 } from 'openapi-types';
 import { type ApiRouteOperationDefinition } from './api-route-operation';
+import { type OpenApiPathItem } from '../types';
 
 export interface ApiRouteParams {
-  openApiPath?: OpenAPIV3_1.PathItemObject;
+  openApiPath?: OpenApiPathItem;
   [ValidMethod.GET]?: ApiRouteOperationDefinition;
   [ValidMethod.PUT]?: ApiRouteOperationDefinition;
   [ValidMethod.POST]?: ApiRouteOperationDefinition;
@@ -46,7 +46,7 @@ export const apiRouteHandler = (methodHandlers: ApiRouteParams) => {
         const route = decodeURIComponent(pathname ?? '');
 
         try {
-          const nrfOasData = getPathsFromMethodHandlers({
+          const nrfOasData = getOasDataFromMethodHandlers({
             methodHandlers,
             route
           });
@@ -66,7 +66,7 @@ ${error}`);
         return;
       }
 
-      const { input, handler, middleware } = methodHandler._config;
+      const { input, handler, middleware } = methodHandler._meta;
 
       if (middleware) {
         await middleware(req, res);
@@ -132,7 +132,7 @@ ${error}`);
   };
 
   handler.getPaths = (route: string) =>
-    getPathsFromMethodHandlers({
+    getOasDataFromMethodHandlers({
       methodHandlers,
       route
     });

--- a/packages/next-rest-framework/src/pages-router/api-route-operation.ts
+++ b/packages/next-rest-framework/src/pages-router/api-route-operation.ts
@@ -6,14 +6,14 @@ import {
   type AnyCase,
   type BaseQuery,
   type BaseStatus,
-  type BaseContentType
+  type BaseContentType,
+  type OpenApiOperation
 } from '../types';
 import {
   type NextApiRequest,
   type NextApiHandler,
   type NextApiResponse
 } from 'next/types';
-import { type OpenAPIV3_1 } from 'openapi-types';
 import { type z } from 'zod';
 
 type TypedNextApiRequest<Body, Query> = Modify<
@@ -148,8 +148,8 @@ type ApiRouteInput<Middleware extends boolean = false> = <
   : Record<string, unknown>);
 
 export interface ApiRouteOperationDefinition {
-  _config: {
-    openApiOperation?: OpenAPIV3_1.OperationObject;
+  _meta: {
+    openApiOperation?: OpenApiOperation;
     input?: InputObject;
     output?: readonly OutputObject[];
     middleware?: NextApiHandler;
@@ -157,7 +157,7 @@ export interface ApiRouteOperationDefinition {
   };
 }
 
-type ApiRouteOperation = (openApiOperation?: OpenAPIV3_1.OperationObject) => {
+type ApiRouteOperation = (openApiOperation?: OpenApiOperation) => {
   input: ApiRouteInput<true>;
   output: ApiRouteOutput<true>;
   middleware: (middleware?: ApiRouteHandler) => {
@@ -173,7 +173,7 @@ export const apiRouteOperation: ApiRouteOperation = (openApiOperation) => {
     middleware: Middleware | undefined,
     handler: Handler | undefined
   ): ApiRouteOperationDefinition => ({
-    _config: {
+    _meta: {
       openApiOperation,
       input,
       output,

--- a/packages/next-rest-framework/src/pages-router/rpc-api-route-handler.ts
+++ b/packages/next-rest-framework/src/pages-router/rpc-api-route-handler.ts
@@ -6,16 +6,21 @@ import {
 import {
   validateSchema,
   logNextRestFrameworkError,
-  type OperationDefinition,
-  getOasDataFromRpcOperations
+  getOasDataFromRpcOperations,
+  type OperationDefinition
 } from '../shared';
 import { type Client } from '../client/rpc-client';
 import { type NextApiRequest, type NextApiResponse } from 'next/types';
+import { type OpenApiOperation, type OpenApiPathItem } from '../types';
 
 export const rpcApiRouteHandler = <
   T extends Record<string, OperationDefinition<any, any>>
 >(
-  operations: T
+  operations: T,
+  options?: {
+    openApiPath?: OpenApiPathItem;
+    openApiOperation?: OpenApiOperation;
+  }
 ) => {
   const handler = async (req: NextApiRequest, res: NextApiResponse) => {
     try {
@@ -36,6 +41,7 @@ export const rpcApiRouteHandler = <
         try {
           const nrfOasData = getOasDataFromRpcOperations({
             operations,
+            options,
             route
           });
 
@@ -111,6 +117,7 @@ ${error}`);
   handler.getPaths = (route: string) =>
     getOasDataFromRpcOperations({
       operations,
+      options,
       route
     });
 

--- a/packages/next-rest-framework/src/types.ts
+++ b/packages/next-rest-framework/src/types.ts
@@ -64,7 +64,27 @@ export interface OutputObject<
   schema: ZodSchema<Body>;
   status: Status;
   contentType: ContentType;
+  name?: string;
 }
+
+export type OpenApiPathItem = Pick<
+  OpenAPIV3_1.PathItemObject,
+  'summary' | 'description' | 'servers' | 'parameters'
+>;
+
+export type OpenApiOperation = Pick<
+  OpenAPIV3_1.OperationObject,
+  | 'tags'
+  | 'summary'
+  | 'description'
+  | 'externalDocs'
+  | 'operationId'
+  | 'parameters'
+  | 'callbacks'
+  | 'deprecated'
+  | 'security'
+  | 'servers'
+>;
 
 export type Modify<T, R> = Omit<T, keyof R> & R;
 

--- a/packages/next-rest-framework/tests/app-router/paths.test.ts
+++ b/packages/next-rest-framework/tests/app-router/paths.test.ts
@@ -443,7 +443,7 @@ it('handles error if the OpenAPI spec generation fails', async () => {
   const error = 'Something went wrong';
 
   jest
-    .spyOn(openApiUtils, 'getPathsFromMethodHandlers')
+    .spyOn(openApiUtils, 'getOasDataFromMethodHandlers')
     .mockImplementation(() => {
       throw Error(error);
     });

--- a/packages/next-rest-framework/tests/app-router/rpc.test.ts
+++ b/packages/next-rest-framework/tests/app-router/rpc.test.ts
@@ -14,7 +14,7 @@ it.each(Object.values(ValidMethod))(
     const data = ['All good!'];
 
     const operation = rpcOperation()
-      .output([z.array(z.string())])
+      .output([{ schema: z.array(z.string()) }])
       .handler(() => data);
 
     const res = await rpcRouteHandler({

--- a/packages/next-rest-framework/tests/pages-router/paths.test.ts
+++ b/packages/next-rest-framework/tests/pages-router/paths.test.ts
@@ -444,7 +444,7 @@ it('handles error if the OpenAPI spec generation fails', async () => {
   const error = 'Something went wrong';
 
   jest
-    .spyOn(openApiUtils, 'getPathsFromMethodHandlers')
+    .spyOn(openApiUtils, 'getOasDataFromMethodHandlers')
     .mockImplementation(() => {
       throw Error(error);
     });

--- a/packages/next-rest-framework/tests/pages-router/rpc.test.ts
+++ b/packages/next-rest-framework/tests/pages-router/rpc.test.ts
@@ -14,7 +14,7 @@ it.each(Object.values(ValidMethod))(
     const data = ['All good!'];
 
     const operation = rpcOperation()
-      .output([z.array(z.string())])
+      .output([{ schema: z.array(z.string()) }])
       .handler(() => data);
 
     await rpcApiRouteHandler({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,7 @@ importers:
 
   .:
     specifiers:
+      '@apidevtools/swagger-cli': 4.0.4
       '@types/node': 20.5.4
       '@types/react': 18.2.21
       '@types/react-dom': 18.2.7
@@ -24,6 +25,7 @@ importers:
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
     devDependencies:
+      '@apidevtools/swagger-cli': 4.0.4_openapi-types@12.1.3
       '@types/node': 20.5.4
       '@types/react': 18.2.21
       '@types/react-dom': 18.2.7
@@ -259,6 +261,52 @@ packages:
     dependencies:
       '@jridgewell/gen-mapping': 0.3.3
       '@jridgewell/trace-mapping': 0.3.19
+
+  /@apidevtools/json-schema-ref-parser/9.0.6:
+    resolution: {integrity: sha512-M3YgsLjI0lZxvrpeGVk9Ap032W6TPQkH6pRAZz81Ac3WUNF79VQooAFnp8umjvVzUmD93NkogxEwbSce7qMsUg==}
+    dependencies:
+      '@jsdevtools/ono': 7.1.3
+      call-me-maybe: 1.0.2
+      js-yaml: 3.14.1
+    dev: true
+
+  /@apidevtools/openapi-schemas/2.1.0:
+    resolution: {integrity: sha512-Zc1AlqrJlX3SlpupFGpiLi2EbteyP7fXmUOGup6/DnkRgjP9bgMM/ag+n91rsv0U1Gpz0H3VILA/o3bW7Ua6BQ==}
+    engines: {node: '>=10'}
+    dev: true
+
+  /@apidevtools/swagger-cli/4.0.4_openapi-types@12.1.3:
+    resolution: {integrity: sha512-hdDT3B6GLVovCsRZYDi3+wMcB1HfetTU20l2DC8zD3iFRNMC6QNAZG5fo/6PYeHWBEv7ri4MvnlKodhNB0nt7g==}
+    engines: {node: '>=10'}
+    deprecated: This package has been abandoned. Please switch to using the actively maintained @redocly/cli
+    hasBin: true
+    dependencies:
+      '@apidevtools/swagger-parser': 10.1.0_openapi-types@12.1.3
+      chalk: 4.1.2
+      js-yaml: 3.14.1
+      yargs: 15.4.1
+    transitivePeerDependencies:
+      - openapi-types
+    dev: true
+
+  /@apidevtools/swagger-methods/3.0.2:
+    resolution: {integrity: sha512-QAkD5kK2b1WfjDS/UQn/qQkbwF31uqRjPTrsCs5ZG9BQGAkjwvqGFjjPqAuzac/IYzpPtRzjCP1WrTuAIjMrXg==}
+    dev: true
+
+  /@apidevtools/swagger-parser/10.1.0_openapi-types@12.1.3:
+    resolution: {integrity: sha512-9Kt7EuS/7WbMAUv2gSziqjvxwDbFSg3Xeyfuj5laUODX8o/k/CpsAKiQ8W7/R88eXFTMbJYg6+7uAmOWNKmwnw==}
+    peerDependencies:
+      openapi-types: '>=7'
+    dependencies:
+      '@apidevtools/json-schema-ref-parser': 9.0.6
+      '@apidevtools/openapi-schemas': 2.1.0
+      '@apidevtools/swagger-methods': 3.0.2
+      '@jsdevtools/ono': 7.1.3
+      ajv: 8.12.0
+      ajv-draft-04: 1.0.0_ajv@8.12.0
+      call-me-maybe: 1.0.2
+      openapi-types: 12.1.3
+    dev: true
 
   /@babel/code-frame/7.22.10:
     resolution: {integrity: sha512-/KKIMG4UEL35WmI9OlvMhurwtytjvXoFcGNrOvyG9zIzA8YmPjVtIZUf7b05+TPO7G7/GEmLHDaoCgACHl9hhA==}
@@ -2712,6 +2760,10 @@ packages:
       '@jridgewell/sourcemap-codec': 1.4.15
     dev: true
 
+  /@jsdevtools/ono/7.1.3:
+    resolution: {integrity: sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg==}
+    dev: true
+
   /@leichtgewicht/ip-codec/2.0.4:
     resolution: {integrity: sha512-Hcv+nVC0kZnQ3tD9GVu5xSMR4VVYOteQIr/hwFPVEvPdlXqgGEuRjiheChHgdM+JyqdgNcmzZOX/tnl0JOiI7A==}
     dev: false
@@ -3669,6 +3721,17 @@ packages:
       indent-string: 4.0.0
     dev: false
 
+  /ajv-draft-04/1.0.0_ajv@8.12.0:
+    resolution: {integrity: sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==}
+    peerDependencies:
+      ajv: ^8.5.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
+    dependencies:
+      ajv: 8.12.0
+    dev: true
+
   /ajv-formats/2.1.1_ajv@8.12.0:
     resolution: {integrity: sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==}
     peerDependencies:
@@ -3711,7 +3774,6 @@ packages:
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
       uri-js: 4.4.1
-    dev: false
 
   /algoliasearch-helper/3.14.0_algoliasearch@4.19.1:
     resolution: {integrity: sha512-gXDXzsSS0YANn5dHr71CUXOo84cN4azhHKUbg71vAWnH+1JBiR4jf7to3t3JHXknXkbV0F7f055vUSBKrltHLQ==}
@@ -4264,6 +4326,10 @@ packages:
       function-bind: 1.1.1
       get-intrinsic: 1.2.1
 
+  /call-me-maybe/1.0.2:
+    resolution: {integrity: sha512-HpX65o1Hnr9HH25ojC1YGs7HCQLq0GCOibSaWER0eNpgJ/Z1MZv2mTc7+xh6WOPxbRVcmgbv4hGU+uSQ/2xFZQ==}
+    dev: true
+
   /callsites/3.1.0:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
     engines: {node: '>=6'}
@@ -4429,6 +4495,14 @@ packages:
 
   /client-only/0.0.1:
     resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
+    dev: true
+
+  /cliui/6.0.0:
+    resolution: {integrity: sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==}
+    dependencies:
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+      wrap-ansi: 6.2.0
     dev: true
 
   /cliui/8.0.1:
@@ -4998,6 +5072,11 @@ packages:
         optional: true
     dependencies:
       ms: 2.1.2
+
+  /decamelize/1.2.0:
+    resolution: {integrity: sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==}
+    engines: {node: '>=0.10.0'}
+    dev: true
 
   /decompress-response/3.3.0:
     resolution: {integrity: sha512-BzRPQuY1ip+qDonAOz42gRm/pg9F768C+npV/4JOsxRC2sq+Rlk+Q4ZCAsOhnIaMrgarILY+RMUIvMmmX1qAEA==}
@@ -7448,7 +7527,6 @@ packages:
 
   /json-schema-traverse/1.0.0:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
-    dev: false
 
   /json-stable-stringify-without-jsonify/1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
@@ -9509,11 +9587,14 @@ packages:
   /require-from-string/2.0.2:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
-    dev: false
 
   /require-like/0.1.2:
     resolution: {integrity: sha512-oyrU88skkMtDdauHDuKVrgR+zuItqr6/c//FXzvmxRGMexSDc6hNvJInGW3LL46n+8b50RykrvwSUIIQH2LQ5A==}
     dev: false
+
+  /require-main-filename/2.0.0:
+    resolution: {integrity: sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==}
+    dev: true
 
   /requires-port/1.0.0:
     resolution: {integrity: sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==}
@@ -9790,6 +9871,10 @@ packages:
     transitivePeerDependencies:
       - supports-color
     dev: false
+
+  /set-blocking/2.0.0:
+    resolution: {integrity: sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==}
+    dev: true
 
   /setimmediate/1.0.5:
     resolution: {integrity: sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==}
@@ -10984,6 +11069,10 @@ packages:
       is-symbol: 1.0.4
     dev: true
 
+  /which-module/2.0.1:
+    resolution: {integrity: sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==}
+    dev: true
+
   /which-typed-array/1.1.11:
     resolution: {integrity: sha512-qe9UWWpkeG5yzZ0tNYxDmd7vo58HDBc39mZ0xWWpolAGADdFOzkfamWLDxkOWcvHQKVmdTyQdLD4NOfjLWTKew==}
     engines: {node: '>= 0.4'}
@@ -11025,6 +11114,15 @@ packages:
 
   /wildcard/2.0.1:
     resolution: {integrity: sha512-CC1bOL87PIWSBhDcTrdeLo6eGT7mCFtrg0uIJtqJUFyK+eJnzl8A1niH56uu7KMa5XFrtiV+AQuHO3n7DsHnLQ==}
+
+  /wrap-ansi/6.2.0:
+    resolution: {integrity: sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==}
+    engines: {node: '>=8'}
+    dependencies:
+      ansi-styles: 4.3.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+    dev: true
 
   /wrap-ansi/7.0.0:
     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
@@ -11106,6 +11204,10 @@ packages:
     engines: {node: '>=0.4'}
     dev: false
 
+  /y18n/4.0.3:
+    resolution: {integrity: sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==}
+    dev: true
+
   /y18n/5.0.8:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
     engines: {node: '>=10'}
@@ -11122,9 +11224,34 @@ packages:
     engines: {node: '>= 6'}
     dev: false
 
+  /yargs-parser/18.1.3:
+    resolution: {integrity: sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==}
+    engines: {node: '>=6'}
+    dependencies:
+      camelcase: 5.3.1
+      decamelize: 1.2.0
+    dev: true
+
   /yargs-parser/21.1.1:
     resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
     engines: {node: '>=12'}
+    dev: true
+
+  /yargs/15.4.1:
+    resolution: {integrity: sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==}
+    engines: {node: '>=8'}
+    dependencies:
+      cliui: 6.0.0
+      decamelize: 1.2.0
+      find-up: 4.1.0
+      get-caller-file: 2.0.5
+      require-directory: 2.1.1
+      require-main-filename: 2.0.0
+      set-blocking: 2.0.0
+      string-width: 4.2.3
+      which-module: 2.0.1
+      y18n: 4.0.3
+      yargs-parser: 18.1.3
     dev: true
 
   /yargs/17.7.2:


### PR DESCRIPTION
This change improves the OpenAPI spec
generation by introducing auto-generated
schema objects that can be used across
different operations.

Additionally, swagger-cli is introduced as
part of the CI pipeline to validate that the
generated OpenAPI document is valid.