### PR TITLE
Add support for multiple middlewares

### DIFF
--- a/docs/docs/api-reference.md
+++ b/docs/docs/api-reference.md
@@ -45,12 +45,12 @@ The following options cam be passed to the `routeHandler` (App Router) and `apiR
 
 The route operation functions `routeOperation` (App Router) and `apiRouteOperation` (Pages Router) allow you to define your API handlers for your endpoints. These functions accept an OpenAPI [Operation object](https://swagger.io/specification/#operation-object) as a parameter, that can be used to override the auto-generated specification. Calling this function allows you to chain your API handler logic with the following functions.
 
-| Name         | Description                                                                                                                    |
-| ------------ | ------------------------------------------------------------------------------------------------------------------------------ |
-| `input`      | A [Route operation input](#route-operation-input) function for defining the validation and documentation of the request.       |
-| `outputs`    | An [Route operation outputs](#route-operation-outputs) function for defining the validation and documentation of the response. |
-| `handler`    | A [Route operation-handler](#route-operation-handler) function for defining your business logic.                               |
-| `middleware` | A [Route operation middleware](#route-operation-middleware) function that gets executed before the request input is validated. |
+| Name         | Description                                                                                                                                                                                                                                                          |
+| ------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `input`      | A [Route operation input](#route-operation-input) function for defining the validation and documentation of the request.                                                                                                                                             |
+| `outputs`    | An [Route operation outputs](#route-operation-outputs) function for defining the validation and documentation of the response.                                                                                                                                       |
+| `handler`    | A [Route operation-handler](#route-operation-handler) function for defining your business logic.                                                                                                                                                                     |
+| `middleware` | A [Route operation middleware](#route-operation-middleware) function that gets executed before the request input is validated. You may chain up to three middlewares together and share data between the middlewares by taking the input of the previous middleware. |
 
 ##### [Route operation input](#route-operation-input)
 
@@ -78,13 +78,47 @@ Calling the route operation outputs function allows you to chain your API handle
 
 ##### [Route operation middleware](#route-operation-middleware)
 
-The route operation middleware function is executed before validating the request input. The function takes in the same parameters as the Next.js [Route Handlers](https://nextjs.org/docs/app/building-your-application/routing/route-handlers) and [API Routes](https://nextjs.org/docs/pages/building-your-application/routing/api-routes) handlers.
+The route operation middleware function is executed before validating the request input. The function takes in the same parameters as the Next.js [Route Handlers](https://nextjs.org/docs/app/building-your-application/routing/route-handlers) and [API Routes](https://nextjs.org/docs/pages/building-your-application/routing/api-routes) handlers. Additionally, as a second parameter this function takes the return value of your last middleware function, defaulting to an empty object. Throwing an error inside a middleware function will stop the execution of the handler and you can also return a custom response like you would do within the [Handler](#handler) function. Calling the route operation middleware function allows you to chain your API handler logic with the [Handler](#handler) function. Alternatively, you may chain up to three middleware functions together:
 
-Calling the route operation middleware function allows you to chain your API handler logic with the [Handler](#handler) function.
+```typescript
+// ...
+const handler = route({
+  getTodos: routeOperation()
+    .middleware(() => {
+      return { foo: 'bar' };
+    })
+    .middleware((_req, _ctx, { foo }) => {
+      // if (myCondition) {
+      //   return NextResponse.json({ error: 'My error.' });
+      // }
+
+      return {
+        foo,
+        bar: 'baz'
+      };
+    })
+    .handler((_req, _ctx, { foo, bar }) => {
+      // ...
+    })
+});
+```
 
 ##### [Route operation handler](#route-operation-handler)
 
-The route operation handler function is a strongly-typed function to implement the business logic for your API. The function takes in strongly-typed versions of the same parameters as the Next.js [Route Handlers](https://nextjs.org/docs/app/building-your-application/routing/route-handlers) and [API Routes](https://nextjs.org/docs/pages/building-your-application/routing/api-routes) handlers.
+The route operation handler function is a strongly-typed function to implement the business logic for your API. The function takes in strongly-typed versions of the same parameters as the Next.js [Route Handlers](https://nextjs.org/docs/app/building-your-application/routing/route-handlers) and [API Routes](https://nextjs.org/docs/pages/building-your-application/routing/api-routes) handlers. Additionally, as a third parameter this function takes the return value of your last middleware function:
+
+```typescript
+// ...
+const handler = route({
+  getTodos: routeOperation()
+    .middleware(() => {
+      return { foo: "bar" };
+    })
+    .handler((_req, _ctx, { foo }) => {
+      // ...
+    });
+});
+```
 
 ### RPC
 
@@ -101,12 +135,12 @@ The `rpcRouteHandler` (App Router) and `rpcApiRouteHandler` (Pages Router) funct
 
 The `rpcOperation` function allows you to define your API handlers for your RPC endpoint. Calling this function allows you to chain your API handler logic with the following functions.
 
-| Name         | Description                                                                                                                   |
-| ------------ | ----------------------------------------------------------------------------------------------------------------------------- |
-| `input`      | An [RPC operation input](#rpc-operation-input) function for defining the validation and documentation of the operation.       |
-| `outputs`    | An [RPC operation outputs](#rpc-operation-outputs) function for defining the validation and documentation of the response.    |
-| `handler`    | An [RPC operation handler](#rpc-operation-handler) function for defining your business logic.                                 |
-| `middleware` | An [RPC operation middleware](#rpc-operation-middleware) function that gets executed before the operation input is validated. |
+| Name         | Description                                                                                                                                                                                                                                                         |
+| ------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `input`      | An [RPC operation input](#rpc-operation-input) function for defining the validation and documentation of the operation.                                                                                                                                             |
+| `outputs`    | An [RPC operation outputs](#rpc-operation-outputs) function for defining the validation and documentation of the response.                                                                                                                                          |
+| `handler`    | An [RPC operation handler](#rpc-operation-handler) function for defining your business logic.                                                                                                                                                                       |
+| `middleware` | An [RPC operation middleware](#rpc-operation-middleware) function that gets executed before the operation input is validated. You may chain up to three middlewares together and share data between the middlewares by taking the input of the previous middleware. |
 
 ##### [RPC operation input](#rpc-operation-input)
 
@@ -127,13 +161,47 @@ Calling the RPC operation outputs function allows you to chain your API handler 
 
 ##### [RPC operation middleware](#rpc-operation-middleware)
 
-The RPC operation middleware function is executed before validating RPC operation input. The function takes in strongly typed parameters typed by the [RPC operation input](#rpc-operation-input) function.
+The RPC operation middleware function is executed before validating RPC operation input. The function takes in strongly typed parameters typed by the [RPC operation input](#rpc-operation-input) function. Additionally, as a second parameter this function takes the return value of your last middleware function, defaulting to an empty object. Throwing an error inside a middleware function will stop the execution of the handler. Calling the RPC operation middleware function allows you to chain your RPC API handler logic with the [RPC operation handler](#rpc-operation-handler) function. Alternatively, you may chain up to three middleware functions together:
 
-Calling the RPC operation middleware function allows you to chain your RPC API handler logic with the [RPC operation handler](#rpc-operation-handler) function.
+```typescript
+// ...
+const handler = rpcRoute({
+  getTodos: rpcOperation()
+    .middleware(() => {
+      return { foo: 'bar' };
+    })
+    .middleware((_input, { foo }) => {
+      // if (myCondition) {
+      //   throw Error('My error.')
+      // }
+
+      return {
+        foo,
+        bar: 'baz'
+      };
+    })
+    .handler((_input, { foo, bar }) => {
+      // ...
+    })
+});
+```
 
 ##### [RPC operation handler](#rpc-operation-handler)
 
-The RPC operation handler function is a strongly-typed function to implement the business logic for your API. The function takes in strongly typed parameters typed by the [RPC operation input](#rpc-operation-input) function.
+The RPC operation handler function is a strongly-typed function to implement the business logic for your API. The function takes in strongly typed parameters typed by the [RPC operation input](#rpc-operation-input) function. Additionally, as a second parameter this function takes the return value of your last middleware function:
+
+```typescript
+// ...
+const handler = rpcApiRoute({
+  getTodos: rpcOperation()
+    .middleware(() => {
+      return { foo: "bar" };
+    })
+    .handler((_input, { foo }) => {
+      // ...
+    });
+});
+```
 
 ## [CLI](#cli)
 

--- a/packages/next-rest-framework/src/shared/rpc-operation.ts
+++ b/packages/next-rest-framework/src/shared/rpc-operation.ts
@@ -1,18 +1,30 @@
+/* eslint-disable @typescript-eslint/no-invalid-void-type */
+
 import { type z, type ZodSchema } from 'zod';
 import { validateSchema } from './schemas';
 import { DEFAULT_ERRORS } from '../constants';
-import { type OpenApiOperation } from '../types';
+import { type BaseOptions, type OpenApiOperation } from '../types';
 
 interface OutputObject {
   schema: ZodSchema;
   name?: string;
 }
 
+type RpcMiddleware<
+  InputOptions extends BaseOptions = BaseOptions,
+  OutputOptions extends BaseOptions = BaseOptions
+> = (
+  params: unknown,
+  options: InputOptions
+) => Promise<OutputOptions> | OutputOptions | Promise<void> | void;
+
 type RpcOperationHandler<
   Input = unknown,
+  Options extends BaseOptions = BaseOptions,
   Outputs extends readonly OutputObject[] = readonly OutputObject[]
 > = (
-  params: z.infer<ZodSchema<Input>>
+  params: z.infer<ZodSchema<Input>>,
+  options: Options
 ) =>
   | Promise<z.infer<Outputs[number]['schema']>>
   | z.infer<Outputs[number]['schema']>;
@@ -21,7 +33,9 @@ interface OperationDefinitionMeta {
   openApiOperation?: OpenApiOperation;
   input?: ZodSchema;
   outputs?: readonly OutputObject[];
-  middleware?: RpcOperationHandler;
+  middleware1?: RpcOperationHandler;
+  middleware2?: RpcOperationHandler;
+  middleware3?: RpcOperationHandler;
   handler?: RpcOperationHandler;
 }
 
@@ -43,41 +57,47 @@ export const rpcOperation = (openApiOperation?: OpenApiOperation) => {
   >(_params: {
     input: ZodSchema<Input>;
     outputs?: Outputs;
-    middleware?: RpcOperationHandler<unknown, Outputs>;
-    handler?: RpcOperationHandler<Input, Outputs>;
+    middleware1?: RpcMiddleware<any, any>;
+    middleware2?: RpcMiddleware<any, any>;
+    middleware3?: RpcMiddleware<any, any>;
+    handler?: RpcOperationHandler<Input, any, Outputs>;
   }): RpcOperationDefinition<Input, Outputs, true>;
 
   function createOperation<Outputs extends readonly OutputObject[]>(_params: {
     outputs?: Outputs;
-    middleware?: RpcOperationHandler<unknown, Outputs>;
-    handler?: RpcOperationHandler<unknown, Outputs>;
+    middleware1?: RpcMiddleware<any, any>;
+    middleware2?: RpcMiddleware<any, any>;
+    middleware3?: RpcMiddleware<any, any>;
+    handler?: RpcOperationHandler<unknown, any, Outputs>;
   }): RpcOperationDefinition<unknown, Outputs, false>;
 
   function createOperation<Input, Outputs extends readonly OutputObject[]>({
     input,
     outputs,
-    middleware,
+    middleware1,
+    middleware2,
+    middleware3,
     handler
   }: {
     input?: ZodSchema<Input>;
     outputs?: Outputs;
-    middleware?: RpcOperationHandler<unknown, Outputs>;
-    handler?: RpcOperationHandler<Input, Outputs>;
+    middleware1?: RpcMiddleware<any, any>;
+    middleware2?: RpcMiddleware<any, any>;
+    middleware3?: RpcMiddleware<any, any>;
+    handler?: RpcOperationHandler<Input, any, Outputs>;
   }): RpcOperationDefinition<Input, Outputs, boolean> {
-    const meta = {
-      openApiOperation,
-      input,
-      outputs,
-      middleware,
-      handler
-    };
-
     const callOperation = async (body?: unknown) => {
-      if (middleware) {
-        const _res = await middleware(body);
+      let middlewareOptions: BaseOptions = {};
 
-        if (_res) {
-          return _res;
+      if (middleware1) {
+        middlewareOptions = await middleware1(body, middlewareOptions);
+
+        if (middleware2) {
+          middlewareOptions = await middleware2(body, middlewareOptions);
+
+          if (middleware3) {
+            middlewareOptions = await middleware3(body, middlewareOptions);
+          }
         }
       }
 
@@ -96,7 +116,18 @@ export const rpcOperation = (openApiOperation?: OpenApiOperation) => {
         throw Error('Handler not found.');
       }
 
-      return await handler(body as z.infer<ZodSchema<Input>>);
+      const res = await handler(body as Input, middlewareOptions);
+      return res;
+    };
+
+    const meta = {
+      openApiOperation,
+      input,
+      outputs,
+      middleware1,
+      middleware2,
+      middleware3,
+      handler
     };
 
     if (input === undefined) {
@@ -104,7 +135,7 @@ export const rpcOperation = (openApiOperation?: OpenApiOperation) => {
       operation._meta = meta;
       return operation as RpcOperationDefinition<unknown, Outputs, false>;
     } else {
-      const operation = async (body: z.infer<ZodSchema<Input>>) =>
+      const operation = async (body: z.infer<ZodSchema>) =>
         await callOperation(body);
 
       operation._meta = meta;
@@ -115,36 +146,117 @@ export const rpcOperation = (openApiOperation?: OpenApiOperation) => {
   return {
     input: <Input>(input: ZodSchema<Input>) => ({
       outputs: <Output extends readonly OutputObject[]>(outputs: Output) => ({
-        middleware: (middleware: RpcOperationHandler<unknown, Output>) => ({
-          handler: (handler: RpcOperationHandler<Input, Output>) =>
+        middleware: <Options1 extends BaseOptions>(
+          middleware1: RpcMiddleware<BaseOptions, Options1>
+        ) => ({
+          middleware: <Options2 extends BaseOptions>(
+            middleware2: RpcMiddleware<Options1, Options2>
+          ) => ({
+            middleware: <Options3 extends BaseOptions>(
+              middleware3: RpcMiddleware<Options2, Options3>
+            ) => ({
+              handler: (
+                handler: RpcOperationHandler<Input, Options3, Output>
+              ) =>
+                createOperation({
+                  input,
+                  outputs,
+                  middleware1,
+                  middleware2,
+                  middleware3,
+                  handler
+                })
+            }),
+            handler: (handler: RpcOperationHandler<Input, Options2, Output>) =>
+              createOperation({
+                input,
+                outputs,
+                middleware1,
+                middleware2,
+                handler
+              })
+          }),
+          handler: (handler: RpcOperationHandler<Input, Options1, Output>) =>
             createOperation({
               input,
               outputs,
-              middleware,
+              middleware1,
               handler
             })
         }),
-        handler: (handler: RpcOperationHandler<Input, Output>) =>
+        handler: (handler: RpcOperationHandler<Input, BaseOptions, Output>) =>
           createOperation({
             input,
             outputs,
             handler
           })
       }),
-      middleware: (middleware: RpcOperationHandler) => ({
-        outputs: <Output extends readonly OutputObject[]>(outputs: Output) => ({
-          handler: (handler: RpcOperationHandler<Input, Output>) =>
+      middleware: <Options1 extends BaseOptions>(
+        middleware1: RpcMiddleware<BaseOptions, Options1>
+      ) => ({
+        middleware: <Options2 extends BaseOptions>(
+          middleware2: RpcMiddleware<Options1, Options2>
+        ) => ({
+          middleware: <Options3 extends BaseOptions>(
+            middleware3: RpcMiddleware<Options2, Options3>
+          ) => ({
+            outputs: <Output extends readonly OutputObject[]>(
+              outputs: Output
+            ) => ({
+              handler: (
+                handler: RpcOperationHandler<Input, Options3, Output>
+              ) =>
+                createOperation({
+                  input,
+                  outputs,
+                  middleware1,
+                  middleware2,
+                  middleware3,
+                  handler
+                })
+            }),
+            handler: (handler: RpcOperationHandler<Input, Options2>) =>
+              createOperation({
+                input,
+                middleware1,
+                middleware2,
+                middleware3,
+                handler
+              })
+          }),
+          outputs: <Output extends readonly OutputObject[]>(
+            outputs: Output
+          ) => ({
+            handler: (handler: RpcOperationHandler<Input, Options2, Output>) =>
+              createOperation({
+                input,
+                outputs,
+                middleware1,
+                middleware2,
+                handler
+              })
+          }),
+          handler: (handler: RpcOperationHandler<Input, Options2>) =>
             createOperation({
               input,
-              outputs,
-              middleware,
+              middleware1,
+              middleware2,
               handler
             })
         }),
-        handler: (handler: RpcOperationHandler<Input>) =>
+        outputs: <Output extends readonly OutputObject[]>(outputs: Output) => ({
+          handler: (handler: RpcOperationHandler<Input, Options1, Output>) =>
+            createOperation({
+              input,
+              outputs,
+              middleware1,
+              handler
+            })
+        }),
+        handler: (handler: RpcOperationHandler<Input, Options1>) =>
           createOperation({
             input,
-            middleware,
+            middleware1,
             handler
           })
       }),
@@ -155,23 +267,64 @@ export const rpcOperation = (openApiOperation?: OpenApiOperation) => {
         })
     }),
     outputs: <Output extends readonly OutputObject[]>(outputs: Output) => ({
-      middleware: (middleware: RpcOperationHandler<unknown, Output>) => ({
-        handler: (handler: RpcOperationHandler<unknown, Output>) =>
+      middleware: <Options1 extends BaseOptions>(
+        middleware1: RpcMiddleware<BaseOptions, Options1>
+      ) => ({
+        middleware: <Options2 extends BaseOptions>(
+          middleware2: RpcMiddleware<Options1, Options2>
+        ) => ({
+          middleware: <Options3 extends BaseOptions>(
+            middleware3: RpcMiddleware<Options2, Options3>
+          ) => ({
+            handler: (
+              handler: RpcOperationHandler<unknown, Options3, Output>
+            ) =>
+              createOperation({
+                outputs,
+                middleware1,
+                middleware2,
+                middleware3,
+                handler
+              })
+          }),
+          handler: (handler: RpcOperationHandler<unknown, Options2, Output>) =>
+            createOperation({
+              outputs,
+              middleware1,
+              middleware2,
+              handler
+            })
+        }),
+        handler: (handler: RpcOperationHandler<unknown, Options1, Output>) =>
           createOperation({
             outputs,
-            middleware,
+            middleware1,
             handler
           })
       }),
-      handler: (handler: RpcOperationHandler<unknown, Output>) =>
+      handler: (handler: RpcOperationHandler<unknown, BaseOptions, Output>) =>
         createOperation({
           outputs,
           handler
         })
     }),
-    middleware: (middleware: RpcOperationHandler) => ({
-      handler: (handler: RpcOperationHandler) =>
-        createOperation({ middleware, handler })
+    middleware: <Options1 extends BaseOptions>(
+      middleware1: RpcMiddleware<BaseOptions, Options1>
+    ) => ({
+      middleware: <Options2 extends BaseOptions>(
+        middleware2: RpcMiddleware<Options1, Options2>
+      ) => ({
+        middleware: <Options3 extends BaseOptions>(
+          middleware3: RpcMiddleware<Options2, Options3>
+        ) => ({
+          handler: (handler: RpcOperationHandler<unknown, Options3>) =>
+            createOperation({ middleware1, middleware2, middleware3, handler })
+        }),
+        handler: (handler: RpcOperationHandler<unknown, Options2>) =>
+          createOperation({ middleware1, middleware2, handler })
+      }),
+      handler: (handler: RpcOperationHandler<unknown, Options1>) =>
+        createOperation({ middleware1, handler })
     }),
     handler: (handler: RpcOperationHandler) => createOperation({ handler })
   };

--- a/packages/next-rest-framework/src/types.ts
+++ b/packages/next-rest-framework/src/types.ts
@@ -76,6 +76,7 @@ export type BaseStatus = number;
 export type BaseContentType = AnyContentTypeWithAutocompleteForMostCommonOnes;
 export type BaseQuery = Record<string, string | string[]>;
 export type BaseParams = Record<string, string>;
+export type BaseOptions = Record<string, unknown>;
 
 export interface OutputObject<
   Body = unknown,


### PR DESCRIPTION
This change allows chaining up to three
middleware functions together and sharing
data between the middlewares.