### PR TITLE
Fix RPC request body parsing 

### DIFF
--- a/apps/example/.eslintrc.json
+++ b/apps/example/.eslintrc.json
@@ -1,6 +1,7 @@
 {
   "extends": "next/core-web-vitals",
   "rules": {
-    "@typescript-eslint/triple-slash-reference": "off"
+    "@typescript-eslint/triple-slash-reference": "off",
+    "@next/next/no-html-link-for-pages": ["error", "./apps/example/src/app"] // When linting from the root of the monorepo.
   }
 }

--- a/packages/next-rest-framework/src/app-router/rpc-route.ts
+++ b/packages/next-rest-framework/src/app-router/rpc-route.ts
@@ -52,10 +52,18 @@ export const rpcRoute = <
       const { input, handler, middleware1, middleware2, middleware3 } =
         operation._meta;
 
+      const parseRequestBody = async (req: NextRequest) => {
+        if (req.clone().body) {
+          return await req.clone().json();
+        }
+
+        return {};
+      };
+
       let middlewareOptions: BaseOptions = {};
 
       if (middleware1) {
-        const body = req.clone().body;
+        const body = await parseRequestBody(req);
 
         middlewareOptions = await middleware1(body, middlewareOptions);
 
@@ -110,7 +118,8 @@ export const rpcRoute = <
         }
       }
 
-      const res = await handler?.(req.clone().body, middlewareOptions);
+      const body = await parseRequestBody(req);
+      const res = await handler?.(body, middlewareOptions);
 
       if (!res) {
         return NextResponse.json(


### PR DESCRIPTION
The request body of an RPC request
was incorrectly passed as a ReadableStream
object for the RPC handlers and middlewares
while it should be passed as JSON.