### PR TITLE
Fix middleware response handling

### DIFF
--- a/packages/next-rest-framework/src/app-router/route.ts
+++ b/packages/next-rest-framework/src/app-router/route.ts
@@ -54,7 +54,7 @@ export const route = <T extends Record<string, RouteOperationDefinition>>(
         const isOptionsResponse = (res: unknown): res is BaseOptions =>
           typeof res === 'object';
 
-        if (res instanceof NextResponse) {
+        if (res instanceof Response) {
           return res;
         } else if (isOptionsResponse(res)) {
           middlewareOptions = res;
@@ -67,7 +67,7 @@ export const route = <T extends Record<string, RouteOperationDefinition>>(
             middlewareOptions
           );
 
-          if (res2 instanceof NextResponse) {
+          if (res2 instanceof Response) {
             return res2;
           } else if (isOptionsResponse(res2)) {
             middlewareOptions = res2;
@@ -80,7 +80,7 @@ export const route = <T extends Record<string, RouteOperationDefinition>>(
               middlewareOptions
             );
 
-            if (res3 instanceof NextResponse) {
+            if (res3 instanceof Response) {
               return res3;
             } else if (isOptionsResponse(res3)) {
               middlewareOptions = res3;


### PR DESCRIPTION
This fixes the handling of custom responses
from the middleware handlers. Comparing the
instance to a `NextResponse` object was not
working while using the `Response` object that
the NextResponse object is also inherited from,
seems to fix the issue so that custom responses
from middlewares work.