### PR TITLE
Fix middleware data passing

### DIFF
--- a/packages/next-rest-framework/src/app-router/route-operation.ts
+++ b/packages/next-rest-framework/src/app-router/route-operation.ts
@@ -146,7 +146,11 @@ type RouteMiddleware<
   req: NextRequest,
   context: { params: BaseParams },
   options: InputOptions
-) => Promise<TypedResponse> | TypedResponse | OutputOptions;
+) =>
+  | Promise<TypedResponse>
+  | TypedResponse
+  | Promise<OutputOptions>
+  | OutputOptions;
 
 type TypedRouteHandler<
   Body = unknown,

--- a/packages/next-rest-framework/src/app-router/rpc-route.ts
+++ b/packages/next-rest-framework/src/app-router/rpc-route.ts
@@ -53,11 +53,11 @@ export const rpcRoute = <
         operation._meta;
 
       const parseRequestBody = async (req: NextRequest) => {
-        if (req.clone().body) {
+        try {
           return await req.clone().json();
+        } catch {
+          return {};
         }
-
-        return {};
       };
 
       let middlewareOptions: BaseOptions = {};

--- a/packages/next-rest-framework/src/pages-router/api-route-operation.ts
+++ b/packages/next-rest-framework/src/pages-router/api-route-operation.ts
@@ -95,7 +95,7 @@ type ApiRouteMiddleware<
     Outputs[number]['contentType']
   >,
   options: InputOptions
-) => Promise<void> | void | OutputOptions;
+) => Promise<void> | void | Promise<OutputOptions> | OutputOptions;
 
 interface InputObject<Body = unknown, Query = BaseQuery> {
   contentType?: BaseContentType;


### PR DESCRIPTION
This fixes a bug where an RPC route
returned an error when a middleware
was used and the operation has no input.

This also fixes the typings for `route`/`apiRoute`
middlewares where asynchronous middleware
function responses were not typed correctly.