### PR TITLE
Fix query parameter OpenAPI generation

### DIFF
--- a/apps/example/public/openapi.json
+++ b/apps/example/public/openapi.json
@@ -6,6 +6,51 @@
     "version": "v5.1.8"
   },
   "paths": {
+    "/api/v1/route-with-query-params": {
+      "get": {
+        "operationId": "getQueryParams",
+        "responses": {
+          "200": {
+            "description": "Response for status 200",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetQueryParams200ResponseBody"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An unknown error occurred, trying again might help.",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/UnexpectedError" }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "foo",
+            "in": "query",
+            "required": true,
+            "schema": { "type": "string", "format": "uuid" }
+          },
+          {
+            "name": "bar",
+            "in": "query",
+            "required": false,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "baz",
+            "in": "query",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ]
+      }
+    },
     "/api/v1/rpc/createTodo": {
       "post": {
         "operationId": "createTodo",
@@ -284,6 +329,51 @@
           }
         ],
         "tags": ["example-api", "todos", "pages-router"]
+      }
+    },
+    "/api/v2/route-with-query-params": {
+      "get": {
+        "operationId": "getQueryParams",
+        "responses": {
+          "200": {
+            "description": "Response for status 200",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetQueryParams200ResponseBody"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An unknown error occurred, trying again might help.",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/UnexpectedError" }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "foo",
+            "in": "query",
+            "required": true,
+            "schema": { "type": "string", "format": "uuid" }
+          },
+          {
+            "name": "bar",
+            "in": "query",
+            "required": false,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "baz",
+            "in": "query",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ]
       }
     },
     "/api/v2/rpc/createTodo": {
@@ -600,6 +690,16 @@
         "type": "object",
         "properties": { "message": { "type": "string" } },
         "required": ["message"],
+        "additionalProperties": false
+      },
+      "GetQueryParams200ResponseBody": {
+        "type": "object",
+        "properties": {
+          "foo": { "type": "string", "format": "uuid" },
+          "bar": { "type": "string" },
+          "baz": { "type": "string" }
+        },
+        "required": ["foo", "baz"],
         "additionalProperties": false
       },
       "GetTodoById200ResponseBody": {

--- a/apps/example/src/app/api/v2/route-with-query-params/route.ts
+++ b/apps/example/src/app/api/v2/route-with-query-params/route.ts
@@ -1,0 +1,37 @@
+import { TypedNextResponse, route, routeOperation } from 'next-rest-framework';
+import { z } from 'zod';
+
+const schema = z.object({
+  foo: z.string().uuid(),
+  bar: z.string().optional(),
+  baz: z.string()
+});
+
+export const dynamic = 'force-dynamic';
+
+// Example app router route handler with query params.
+export const { GET } = route({
+  getQueryParams: routeOperation({
+    method: 'GET'
+  })
+    .input({
+      contentType: 'application/json',
+      query: schema
+    })
+    .outputs([
+      {
+        status: 200,
+        contentType: 'application/json',
+        schema
+      }
+    ])
+    .handler((req) => {
+      const query = req.nextUrl.searchParams;
+
+      return TypedNextResponse.json({
+        foo: query.get('foo') ?? '',
+        bar: query.get('bar') ?? '',
+        baz: query.get('baz') ?? ''
+      });
+    })
+});

--- a/apps/example/src/pages/api/v1/route-with-query-params/index.ts
+++ b/apps/example/src/pages/api/v1/route-with-query-params/index.ts
@@ -1,0 +1,29 @@
+import { apiRoute, apiRouteOperation } from 'next-rest-framework';
+import { z } from 'zod';
+
+const schema = z.object({
+  foo: z.string().uuid(),
+  bar: z.string().optional(),
+  baz: z.string()
+});
+
+// Example pages router API route handler with query params.
+export default apiRoute({
+  getQueryParams: apiRouteOperation({
+    method: 'GET'
+  })
+    .input({
+      contentType: 'application/json',
+      query: schema
+    })
+    .outputs([
+      {
+        status: 200,
+        contentType: 'application/json',
+        schema
+      }
+    ])
+    .handler((req, res) => {
+      res.json(req.query);
+    })
+});

--- a/docs/docs/getting-started.md
+++ b/docs/docs/getting-started.md
@@ -34,12 +34,6 @@ import { docsRoute } from 'next-rest-framework';
 export const { GET } = docsRoute();
 ```
 
-When using the default `nodejs` runtime, you may encounter the [Dynamic server usage](https://nextjs.org/docs/messages/dynamic-server-error) Next.js error when running `next build`. In that case you should force the route to be dynamically rendered with the [dynamic](https://nextjs.org/docs/app/api-reference/file-conventions/route-segment-config#dynamic) option:
-
-```typescript
-export const dynamic = 'force-dynamic';
-```
-
 #### [Pages router docs API route](#pages-router-docs-api-route):
 
 ```typescript
@@ -154,6 +148,12 @@ export const { GET, POST } = route({
 ```
 
 The `TypedNextResponse` ensures that the response status codes and content-type headers are type-checked. You can still use the regular `NextResponse` if you prefer to have less type-safety.
+
+When using the default `nodejs` runtime with app router routes (`docsRoute` or `route`), you may encounter the [Dynamic server usage](https://nextjs.org/docs/messages/dynamic-server-error) Next.js error when running `next build`. In that case you should force the route to be dynamically rendered with the [dynamic](https://nextjs.org/docs/app/api-reference/file-conventions/route-segment-config#dynamic) option:
+
+```typescript
+export const dynamic = 'force-dynamic';
+```
 
 ##### [Pages router API route](#pages-router-api-route):
 

--- a/packages/next-rest-framework/README.md
+++ b/packages/next-rest-framework/README.md
@@ -123,12 +123,6 @@ import { docsRoute } from 'next-rest-framework';
 export const { GET } = docsRoute();
 ```
 
-When using the default `nodejs` runtime, you may encounter the [Dynamic server usage](https://nextjs.org/docs/messages/dynamic-server-error) Next.js error when running `next build`. In that case you should force the route to be dynamically rendered with the [dynamic](https://nextjs.org/docs/app/api-reference/file-conventions/route-segment-config#dynamic) option:
-
-```typescript
-export const dynamic = 'force-dynamic';
-```
-
 #### [Pages router docs API route](#pages-router-docs-api-route):
 
 ```typescript
@@ -243,6 +237,12 @@ export const { GET, POST } = route({
 ```
 
 The `TypedNextResponse` ensures that the response status codes and content-type headers are type-checked. You can still use the regular `NextResponse` if you prefer to have less type-safety.
+
+When using the default `nodejs` runtime with app router routes (`docsRoute` or `route`), you may encounter the [Dynamic server usage](https://nextjs.org/docs/messages/dynamic-server-error) Next.js error when running `next build`. In that case you should force the route to be dynamically rendered with the [dynamic](https://nextjs.org/docs/app/api-reference/file-conventions/route-segment-config#dynamic) option:
+
+```typescript
+export const dynamic = 'force-dynamic';
+```
 
 ##### [Pages router API route](#pages-router-api-route):
 

--- a/packages/next-rest-framework/package.json
+++ b/packages/next-rest-framework/package.json
@@ -42,11 +42,13 @@
     "lodash": "4.17.21",
     "prettier": "3.0.2",
     "tiny-glob": "0.2.9",
-    "zod-to-json-schema": "3.21.4"
+    "zod-to-json-schema": "3.21.4",
+    "qs": "6.11.2"
   },
   "devDependencies": {
     "@types/jest": "29.5.4",
     "@types/lodash": "4.14.197",
+    "@types/qs": "6.9.11",
     "jest": "29.6.4",
     "node-mocks-http": "1.13.0",
     "openapi-types": "12.1.3",

--- a/packages/next-rest-framework/src/app-router/route.ts
+++ b/packages/next-rest-framework/src/app-router/route.ts
@@ -1,17 +1,18 @@
 import { NextRequest, NextResponse } from 'next/server';
+import qs from 'qs';
 import { DEFAULT_ERRORS } from '../constants';
-import {
-  type OpenApiPathItem,
-  type BaseParams,
-  type BaseOptions
-} from '../types';
 import { validateSchema } from '../shared';
-import {
-  type TypedNextRequest,
-  type RouteOperationDefinition
-} from './route-operation';
 import { logNextRestFrameworkError } from '../shared/logging';
 import { getPathsFromRoute } from '../shared/paths';
+import {
+  type BaseOptions,
+  type BaseParams,
+  type OpenApiPathItem
+} from '../types';
+import {
+  type RouteOperationDefinition,
+  type TypedNextRequest
+} from './route-operation';
 
 export const route = <T extends Record<string, RouteOperationDefinition>>(
   operations: T,
@@ -138,7 +139,7 @@ export const route = <T extends Record<string, RouteOperationDefinition>>(
         if (querySchema) {
           const { valid, errors } = await validateSchema({
             schema: querySchema,
-            obj: Object.fromEntries(new URLSearchParams(req.nextUrl.search))
+            obj: qs.parse(req.nextUrl.search, { ignoreQueryPrefix: true })
           });
 
           if (!valid) {

--- a/packages/next-rest-framework/tests/pages-router/api-route.test.ts
+++ b/packages/next-rest-framework/tests/pages-router/api-route.test.ts
@@ -162,6 +162,51 @@ describe('apiRoute', () => {
     });
   });
 
+  it('works with valid query parameters', async () => {
+    const query = {
+      foo: 'bar'
+    };
+
+    const { req, res } = createMockApiRouteRequest({
+      method: ValidMethod.POST,
+      query,
+      headers: {
+        'content-type': 'application/json'
+      }
+    });
+
+    const schema = z.object({
+      foo: z.string()
+    });
+
+    await apiRoute({
+      test: apiRouteOperation({ method: 'POST' })
+        .input({
+          contentType: 'application/json',
+          query: schema
+        })
+        .outputs([
+          {
+            status: 200,
+            contentType: 'application/json',
+            schema: z.object({
+              foo: z.string()
+            })
+          }
+        ])
+        .handler((req, res) => {
+          const { foo } = req.query;
+          res.json({ foo });
+        })
+    })(req, res);
+
+    expect(res.statusCode).toEqual(200);
+
+    expect(res._getJSONData()).toEqual({
+      foo: 'bar'
+    });
+  });
+
   it('returns error for invalid content-type', async () => {
     const { req, res } = createMockApiRouteRequest({
       method: ValidMethod.POST,

--- a/packages/next-rest-framework/tests/utils.ts
+++ b/packages/next-rest-framework/tests/utils.ts
@@ -18,6 +18,7 @@ import { type BaseParams, type Modify } from '../src/types';
 import { type OpenAPIV3_1 } from 'openapi-types';
 import { getJsonSchema } from '../src/shared';
 import { OPEN_API_VERSION } from '../src/cli/constants';
+import qs from 'qs';
 
 export const createMockRouteRequest = <Body, Query>({
   path = '/',
@@ -37,20 +38,15 @@ export const createMockRouteRequest = <Body, Query>({
   req: NextRequest;
   context: { params: typeof params };
 } => ({
-  req: new NextRequest(
-    `http://localhost:3000${path}${
-      query ? `?${new URLSearchParams(query).toString()}` : ''
-    }`,
-    {
-      method,
-      body: JSON.stringify(body),
-      headers: {
-        host: 'localhost:3000',
-        'x-forwarded-proto': 'http',
-        ...headers
-      }
+  req: new NextRequest(`http://localhost:3000${path}?${qs.stringify(query)}`, {
+    method,
+    body: JSON.stringify(body),
+    headers: {
+      host: 'localhost:3000',
+      'x-forwarded-proto': 'http',
+      ...headers
     }
-  ),
+  }),
   context: { params }
 });
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -128,6 +128,9 @@ importers:
       prettier:
         specifier: 3.0.2
         version: 3.0.2
+      qs:
+        specifier: 6.11.2
+        version: 6.11.2
       tiny-glob:
         specifier: 0.2.9
         version: 0.2.9
@@ -141,6 +144,9 @@ importers:
       '@types/lodash':
         specifier: 4.14.197
         version: 4.14.197
+      '@types/qs':
+        specifier: 6.9.11
+        version: 6.9.11
       jest:
         specifier: 29.6.4
         version: 29.6.4(@types/node@20.5.4)(ts-node@10.9.1)
@@ -3598,7 +3604,7 @@ packages:
     resolution: {integrity: sha512-zbivROJ0ZqLAtMzgzIUC4oNqDG9iF0lSsAqpOD9kbs5xcIM3dTiyuHvBc7R8MtWBp3AAWGaovJa+wzWPjLYW7Q==}
     dependencies:
       '@types/node': 20.5.4
-      '@types/qs': 6.9.7
+      '@types/qs': 6.9.11
       '@types/range-parser': 1.2.4
       '@types/send': 0.17.1
     dev: false
@@ -3608,7 +3614,7 @@ packages:
     dependencies:
       '@types/body-parser': 1.19.2
       '@types/express-serve-static-core': 4.17.36
-      '@types/qs': 6.9.7
+      '@types/qs': 6.9.11
       '@types/serve-static': 1.15.2
     dev: false
 
@@ -3710,9 +3716,8 @@ packages:
   /@types/prop-types@15.7.5:
     resolution: {integrity: sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w==}
 
-  /@types/qs@6.9.7:
-    resolution: {integrity: sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw==}
-    dev: false
+  /@types/qs@6.9.11:
+    resolution: {integrity: sha512-oGk0gmhnEJK4Yyk+oI7EfXsLayXatCWPHary1MtcmbAifkobT9cM9yutG/hZKIseOU0MqbIwQ/u2nn/Gb+ltuQ==}
 
   /@types/range-parser@1.2.4:
     resolution: {integrity: sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==}
@@ -4762,7 +4767,7 @@ packages:
   /call-bind@1.0.2:
     resolution: {integrity: sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==}
     dependencies:
-      function-bind: 1.1.1
+      function-bind: 1.1.2
       get-intrinsic: 1.2.1
 
   /call-me-maybe@1.0.2:
@@ -6670,7 +6675,6 @@ packages:
 
   /function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
-    dev: true
 
   /function.prototype.name@1.1.5:
     resolution: {integrity: sha512-uN7m/BzVKQnCUF/iW8jYea67v++2u7m5UgENbHRtdDVclOUP+FMPlCNdmk0h/ysGyo2tavMJEDqJAkJdRa1vMA==}
@@ -6698,7 +6702,7 @@ packages:
   /get-intrinsic@1.2.1:
     resolution: {integrity: sha512-2DcsyfABl+gVHEfCOaTrWgyt+tb6MSEGmKq+kI5HwLbIYgjgmMcV8KQ41uaKz1xxUcn9tJtgFbQUEVcEbd0FYw==}
     dependencies:
-      function-bind: 1.1.1
+      function-bind: 1.1.2
       has: 1.0.3
       has-proto: 1.0.1
       has-symbols: 1.0.3
@@ -9665,6 +9669,13 @@ packages:
 
   /qs@6.11.0:
     resolution: {integrity: sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==}
+    engines: {node: '>=0.6'}
+    dependencies:
+      side-channel: 1.0.4
+    dev: false
+
+  /qs@6.11.2:
+    resolution: {integrity: sha512-tDNIz22aBzCDxLtVH++VnTfzxlfeK5CbqohpSqpJgj1Wg/cQbStNAz3NuqCs5vV+pjBsK4x4pN9HlVh7rcYRiA==}
     engines: {node: '>=0.6'}
     dependencies:
       side-channel: 1.0.4


### PR DESCRIPTION
The OpenAPI spec generation for query
parameters ended up adding unnecessary
union types for the generated schema which
is fixed here.

The query parameter parsing is now done with
the `qs` library instead of the previous manual
parsing and some test coverage is added to handle
both valid and invalid query parameter calls.