### PR TITLE
Remove ESBuild extenal packages option from CLI bundling

### DIFF
--- a/packages/next-rest-framework/src/cli/utils.ts
+++ b/packages/next-rest-framework/src/cli/utils.ts
@@ -36,8 +36,7 @@ export const compileEndpoints = async () => {
     format: 'cjs',
     platform: 'node',
     outdir: NEXT_REST_FRAMEWORK_TEMP_FOLDER_NAME,
-    outExtension: { '.js': '.cjs' },
-    packages: 'external'
+    outExtension: { '.js': '.cjs' }
   });
 };
 


### PR DESCRIPTION
This option resulted in the CLI not working for some users due to the required dependencies not being resolved.