### PR TITLE
Remove `suppressInfo` config option

### DIFF
--- a/docs/docs/api-reference.md
+++ b/docs/docs/api-reference.md
@@ -15,7 +15,6 @@ The following options can be passed to the `docsRoute` (app router) and `docsApi
 | `openApiObject`   | An [OpenAPI Object](https://swagger.io/specification/#openapi-object) that can be used to override and extend the auto-generated specification.                                                                                                                                                                        |
 | `openApiJsonPath` | Path that will be used for fetching the OpenAPI spec - defaults to `/openapi.json`. This path also determines the path where this file will be generated inside the `public` folder.                                                                                                                                   |
 | `docsConfig`      | A [Docs config](#docs-config) object for customizing the generated docs.                                                                                                                                                                                                                                               |
-| `suppressInfo`    | Setting this to `true` will suppress all informational logs from Next REST Framework. Defaults to `false`.                                                                                                                                                                                                             |
 
 ### [Docs config](#docs-config)
 
@@ -27,8 +26,8 @@ The docs config options can be used to customize the generated docs:
 | `title`       | Custom title, used for the visible title and HTML title.                                                                                     |
 | `description` | Custom description, used for the visible description and HTML meta description.                                                              |
 | `faviconUrl`  | Custom HTML meta favicon URL.                                                                                                                |
-| `ogConfig`    | [Basic customization options](https://ogp.me/#metadata) for OG meta tags. Requires the following fields: `title`, `type`, `url`, `imageUrl`. |
 | `logoUrl`     | A URL for a custom logo.                                                                                                                     |
+| `ogConfig`    | [Basic customization options](https://ogp.me/#metadata) for OG meta tags. Requires the following fields: `title`, `type`, `url`, `imageUrl`. |
 
 ### REST
 
@@ -43,7 +42,7 @@ The following options can be passed to the `routeHandler` (app router) and `apiR
 
 #### [Route operations](#route-operations)
 
-The route operation functions `routeOperation` (app router) and `apiRouteOperation` (pages router) allow you to define your API handlers for your endpoints. These functions accept an OpenAPI [Operation object](https://swagger.io/specification/#operation-object) as a parameter, that can be used to override the auto-generated specification. Calling this function allows you to chain your API handler logic with the following functions.
+The route operation functions `routeOperation` (app router) and `apiRouteOperation` (pages router) allow you to define your API handlers for your endpoints. These functions accept an OpenAPI [Operation object](https://swagger.io/specification/#operation-object) as a parameter, that can be used to override the auto-generated specification. Calling this function allows you to chain your API handler logic with the following functions:
 
 | Name         | Description                                                                                                                                                                                                                                                          |
 | ------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -124,14 +123,9 @@ const handler = route({
 
 #### [RPC route handler options](#rpc-route-handler-options)
 
-The `rpcRouteHandler` (app router) and `rpcApiRouteHandler` (pages router) functions allow the following options as the second parameter after passing your RPC operations.
+The `rpcRouteHandler` (app router) and `rpcApiRouteHandler` (pages router) functions allow you to define your API handlers for your RPC endpoints. These functions accept an OpenAPI [Operation object](https://swagger.io/specification/#operation-object) as a parameter, that can be used to override the auto-generated specification.
 
-| Name               | Description                                                                                                                                                 | Required |
-| ------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- |
-| `openApiPath`      | An OpenAPI [Path Item Object](https://swagger.io/specification/#path-item-object) that can be used to override and extend the auto-generated specification. | `false`  |
-| `openApiOperation` | An OpenAPI [Path Item Object](https://swagger.io/specification/#operation-object) that can be used to override and extend the auto-generated specification. | `false`  |
-
-#### [RPC operations](#rpc-route-operations)
+#### [RPC operations](#rpc-operations)
 
 The `rpcOperation` function allows you to define your API handlers for your RPC endpoint. Calling this function allows you to chain your API handler logic with the following functions.
 
@@ -219,10 +213,7 @@ The `next-rest-framework validate` command is useful to have as part of the stat
 A good practice is to set these in your `package.json` as both commands are needed:
 
 ```json
-// package.json
-...
 "scripts": {
-  ...
   "generate": "next-rest-framework generate",
   "validate": "next-rest-framework validate",
 }

--- a/packages/next-rest-framework/README.md
+++ b/packages/next-rest-framework/README.md
@@ -554,7 +554,6 @@ The following options can be passed to the `docsRoute` (app router) and `docsApi
 | `openApiObject`   | An [OpenAPI Object](https://swagger.io/specification/#openapi-object) that can be used to override and extend the auto-generated specification.                                                                                                                                                                        |
 | `openApiJsonPath` | Path that will be used for fetching the OpenAPI spec - defaults to `/openapi.json`. This path also determines the path where this file will be generated inside the `public` folder.                                                                                                                                   |
 | `docsConfig`      | A [Docs config](#docs-config) object for customizing the generated docs.                                                                                                                                                                                                                                               |
-| `suppressInfo`    | Setting this to `true` will suppress all informational logs from Next REST Framework. Defaults to `false`.                                                                                                                                                                                                             |
 
 ### [Docs config](#docs-config)
 
@@ -582,7 +581,7 @@ The following options can be passed to the `routeHandler` (app router) and `apiR
 
 #### [Route operations](#route-operations)
 
-The route operation functions `routeOperation` (app router) and `apiRouteOperation` (pages router) allow you to define your API handlers for your endpoints. These functions accept an OpenAPI [Operation object](https://swagger.io/specification/#operation-object) as a parameter, that can be used to override the auto-generated specification. Calling this function allows you to chain your API handler logic with the following functions.
+The route operation functions `routeOperation` (app router) and `apiRouteOperation` (pages router) allow you to define your API handlers for your endpoints. These functions accept an OpenAPI [Operation object](https://swagger.io/specification/#operation-object) as a parameter, that can be used to override the auto-generated specification. Calling this function allows you to chain your API handler logic with the following functions:
 
 | Name         | Description                                                                                                                                                                                                                                                          |
 | ------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -663,14 +662,9 @@ const handler = route({
 
 #### [RPC route handler options](#rpc-route-handler-options)
 
-The `rpcRouteHandler` (app router) and `rpcApiRouteHandler` (pages router) functions allow the following options as the second parameter after passing your RPC operations.
+The `rpcRouteHandler` (app router) and `rpcApiRouteHandler` (pages router) functions allow you to define your API handlers for your RPC endpoints. These functions accept an OpenAPI [Operation object](https://swagger.io/specification/#operation-object) as a parameter, that can be used to override the auto-generated specification.
 
-| Name               | Description                                                                                                                                                 | Required |
-| ------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- |
-| `openApiPath`      | An OpenAPI [Path Item Object](https://swagger.io/specification/#path-item-object) that can be used to override and extend the auto-generated specification. | `false`  |
-| `openApiOperation` | An OpenAPI [Path Item Object](https://swagger.io/specification/#operation-object) that can be used to override and extend the auto-generated specification. | `false`  |
-
-#### [RPC operations](#rpc-route-operations)
+#### [RPC operations](#rpc-operations)
 
 The `rpcOperation` function allows you to define your API handlers for your RPC endpoint. Calling this function allows you to chain your API handler logic with the following functions.
 
@@ -758,10 +752,7 @@ The `next-rest-framework validate` command is useful to have as part of the stat
 A good practice is to set these in your `package.json` as both commands are needed:
 
 ```json
-// package.json
-...
 "scripts": {
-  ...
   "generate": "next-rest-framework generate",
   "validate": "next-rest-framework validate",
 }

--- a/packages/next-rest-framework/src/shared/config.ts
+++ b/packages/next-rest-framework/src/shared/config.ts
@@ -33,8 +33,7 @@ export const DEFAULT_CONFIG: Required<NextRestFrameworkConfig> = {
       url: HOMEPAGE,
       imageUrl: DEFAULT_LOGO_URL
     }
-  },
-  suppressInfo: false
+  }
 };
 
 export const getConfig = (config?: NextRestFrameworkConfig) =>

--- a/packages/next-rest-framework/src/types.ts
+++ b/packages/next-rest-framework/src/types.ts
@@ -73,8 +73,6 @@ export interface NextRestFrameworkConfig {
       imageUrl: string /*! og:image */;
     };
   };
-  /*! Setting this to `true` will suppress all informational logs from Next REST Framework. Defaults to `false`. */
-  suppressInfo?: boolean;
 }
 
 export type BaseStatus = number;


### PR DESCRIPTION
This is dead code and not used for anything
anymore. This also fixes some misinformation
in the docs.