### PR TITLE
Fix CLI bundling glob for npm/npx

### DIFF
--- a/packages/next-rest-framework/package.json
+++ b/packages/next-rest-framework/package.json
@@ -41,7 +41,7 @@
     "esbuild": "0.19.11",
     "lodash": "4.17.21",
     "prettier": "3.0.2",
-    "tiny-glob": "0.2.9",
+    "fast-glob": "3.3.2",
     "zod-to-json-schema": "3.21.4",
     "qs": "6.11.2"
   },

--- a/packages/next-rest-framework/src/cli/utils.ts
+++ b/packages/next-rest-framework/src/cli/utils.ts
@@ -1,6 +1,6 @@
 import { rm } from 'fs/promises';
 import chalk from 'chalk';
-import glob from 'tiny-glob';
+import { globSync } from 'fast-glob';
 import { build } from 'esbuild';
 import { type NrfOasData } from '../shared/paths';
 import { type NextRestFrameworkConfig } from '../types';
@@ -27,7 +27,7 @@ export const clearTmpFolder = async () => {
 export const compileEndpoints = async () => {
   await clearTmpFolder();
   console.info(chalk.yellowBright('Compiling endpoints...'));
-  const entryPoints = await glob('./**/*.ts');
+  const entryPoints = globSync(['./**/*.ts', '!**/node_modules/**']);
 
   // Bundle to CJS modules and use an explicit .cjs extension to make the file imports work in other parts of the CLI.
   await build({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -122,6 +122,9 @@ importers:
       esbuild:
         specifier: 0.19.11
         version: 0.19.11
+      fast-glob:
+        specifier: 3.3.2
+        version: 3.3.2
       lodash:
         specifier: 4.17.21
         version: 4.17.21
@@ -131,9 +134,6 @@ importers:
       qs:
         specifier: 6.11.2
         version: 6.11.2
-      tiny-glob:
-        specifier: 0.2.9
-        version: 0.2.9
       zod-to-json-schema:
         specifier: 3.21.4
         version: 3.21.4(zod@3.22.2)
@@ -5142,7 +5142,7 @@ packages:
     peerDependencies:
       webpack: ^5.1.0
     dependencies:
-      fast-glob: 3.3.1
+      fast-glob: 3.3.2
       glob-parent: 6.0.2
       globby: 13.2.2
       normalize-path: 3.0.0
@@ -6019,7 +6019,7 @@ packages:
       eslint: 8.47.0
       eslint-module-utils: 2.8.0(@typescript-eslint/parser@6.4.1)(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.47.0)
       eslint-plugin-import: 2.28.1(@typescript-eslint/parser@6.4.1)(eslint-import-resolver-typescript@3.6.1)(eslint@8.47.0)
-      fast-glob: 3.3.1
+      fast-glob: 3.3.2
       get-tsconfig: 4.7.2
       is-core-module: 2.13.0
       is-glob: 4.0.3
@@ -6402,6 +6402,17 @@ packages:
 
   /fast-glob@3.3.1:
     resolution: {integrity: sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==}
+    engines: {node: '>=8.6.0'}
+    dependencies:
+      '@nodelib/fs.stat': 2.0.5
+      '@nodelib/fs.walk': 1.2.8
+      glob-parent: 5.1.2
+      merge2: 1.4.1
+      micromatch: 4.0.5
+    dev: true
+
+  /fast-glob@3.3.2:
+    resolution: {integrity: sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==}
     engines: {node: '>=8.6.0'}
     dependencies:
       '@nodelib/fs.stat': 2.0.5
@@ -6840,17 +6851,13 @@ packages:
       define-properties: 1.2.0
     dev: true
 
-  /globalyzer@0.1.0:
-    resolution: {integrity: sha512-40oNTM9UfG6aBmuKxk/giHn5nQ8RVz/SS4Ir6zgzOv9/qC3kKZ9v4etGTcJbEl/NyVQH7FGU7d+X1egr57Md2Q==}
-    dev: false
-
   /globby@11.1.0:
     resolution: {integrity: sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==}
     engines: {node: '>=10'}
     dependencies:
       array-union: 2.1.0
       dir-glob: 3.0.1
-      fast-glob: 3.3.1
+      fast-glob: 3.3.2
       ignore: 5.2.4
       merge2: 1.4.1
       slash: 3.0.0
@@ -6860,14 +6867,10 @@ packages:
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
     dependencies:
       dir-glob: 3.0.1
-      fast-glob: 3.3.1
+      fast-glob: 3.3.2
       ignore: 5.2.4
       merge2: 1.4.1
       slash: 4.0.0
-    dev: false
-
-  /globrex@0.1.2:
-    resolution: {integrity: sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==}
     dev: false
 
   /gopd@1.0.1:
@@ -11004,13 +11007,6 @@ packages:
 
   /thunky@1.1.0:
     resolution: {integrity: sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA==}
-    dev: false
-
-  /tiny-glob@0.2.9:
-    resolution: {integrity: sha512-g/55ssRPUjShh+xkfx9UPDXqhckHEsHr4Vd9zX55oSdGZc/MD0m3sferOkwWtp98bv+kcVfEHtRJgBVJzelrzg==}
-    dependencies:
-      globalyzer: 0.1.0
-      globrex: 0.1.2
     dev: false
 
   /tiny-invariant@1.3.1:


### PR DESCRIPTION
The ESBuild process for the CLI commands
fails when run with npm/npx due to the dependencies being resolved differently than with pnpm, resulting in the dependencies at node_modules folder being resolved by ESBuild when running the CLI commands with npm/npx.

To fix this, the `tiny-glob` package is replaced with an alternative `fast-glob` that allows us to explicitly exclude all node_modules files from the globbing output, fixing the issue.