### PR TITLE
Improve form support

### DIFF
--- a/apps/example/package.json
+++ b/apps/example/package.json
@@ -11,7 +11,8 @@
     "lint": "tsc && next lint"
   },
   "dependencies": {
-    "next-rest-framework": "workspace:*"
+    "next-rest-framework": "workspace:*",
+    "zod-form-data": "2.0.2"
   },
   "devDependencies": {
     "autoprefixer": "10.0.1",

--- a/apps/example/public/openapi.json
+++ b/apps/example/public/openapi.json
@@ -6,6 +6,74 @@
     "version": "v5.1.12"
   },
   "paths": {
+    "/api/v1/form-data/multipart": {
+      "post": {
+        "operationId": "multipartFormData",
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "$ref": "#/components/schemas/MultipartFormDataRequestBody"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Response for status 200",
+            "content": {
+              "application/octet-stream": {
+                "schema": {
+                  "$ref": "#/components/schemas/MultipartFormData200ResponseBody"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An unknown error occurred, trying again might help.",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/UnexpectedError" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/form-data/url-encoded": {
+      "post": {
+        "operationId": "urlEncodedFormData",
+        "requestBody": {
+          "content": {
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "$ref": "#/components/schemas/UrlEncodedFormDataRequestBody"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Response for status 200",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UrlEncodedFormData200ResponseBody"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An unknown error occurred, trying again might help.",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/UnexpectedError" }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/v1/route-with-query-params": {
       "get": {
         "operationId": "getQueryParams",
@@ -80,8 +148,7 @@
               }
             }
           }
-        },
-        "tags": ["RPC"]
+        }
       }
     },
     "/api/v1/rpc/deleteTodo": {
@@ -113,8 +180,75 @@
               }
             }
           }
+        }
+      }
+    },
+    "/api/v1/rpc/formDataMultipart": {
+      "post": {
+        "operationId": "formDataMultipart",
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "$ref": "#/components/schemas/FormDataMultipartRequestBody"
+              }
+            }
+          }
         },
-        "tags": ["RPC"]
+        "responses": {
+          "200": {
+            "description": "FormDataMultipartResponseBody",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FormDataMultipartResponseBody"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "An unknown error occurred, trying again might help.",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/UnexpectedError" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/rpc/formDataUrlEncoded": {
+      "post": {
+        "operationId": "formDataUrlEncoded",
+        "requestBody": {
+          "content": {
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "$ref": "#/components/schemas/FormDataUrlEncodedRequestBody"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "FormDataUrlEncodedResponseBody",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FormDataUrlEncodedResponseBody"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "An unknown error occurred, trying again might help.",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/UnexpectedError" }
+              }
+            }
+          }
+        }
       }
     },
     "/api/v1/rpc/getTodoById": {
@@ -148,8 +282,7 @@
               }
             }
           }
-        },
-        "tags": ["RPC"]
+        }
       }
     },
     "/api/v1/rpc/getTodos": {
@@ -174,8 +307,7 @@
               }
             }
           }
-        },
-        "tags": ["RPC"]
+        }
       }
     },
     "/api/v1/todos": {
@@ -200,8 +332,7 @@
               }
             }
           }
-        },
-        "tags": ["example-api", "todos", "pages-router"]
+        }
       },
       "post": {
         "operationId": "createTodo",
@@ -241,8 +372,7 @@
               }
             }
           }
-        },
-        "tags": ["example-api", "todos", "pages-router"]
+        }
       }
     },
     "/api/v1/todos/{id}": {
@@ -285,8 +415,7 @@
             "required": true,
             "schema": { "type": "string" }
           }
-        ],
-        "tags": ["example-api", "todos", "pages-router"]
+        ]
       },
       "delete": {
         "operationId": "deleteTodo",
@@ -327,8 +456,75 @@
             "required": true,
             "schema": { "type": "string" }
           }
-        ],
-        "tags": ["example-api", "todos", "pages-router"]
+        ]
+      }
+    },
+    "/api/v2/form-data/multipart": {
+      "post": {
+        "operationId": "multipartFormData",
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "$ref": "#/components/schemas/MultipartFormDataRequestBody"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Response for status 200",
+            "content": {
+              "application/octet-stream": {
+                "schema": {
+                  "$ref": "#/components/schemas/MultipartFormData200ResponseBody"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An unknown error occurred, trying again might help.",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/UnexpectedError" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v2/form-data/url-encoded": {
+      "post": {
+        "operationId": "urlEncodedFormData",
+        "requestBody": {
+          "content": {
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "$ref": "#/components/schemas/UrlEncodedFormDataRequestBody"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Response for status 200",
+            "content": {
+              "application/octet-stream": {
+                "schema": {
+                  "$ref": "#/components/schemas/UrlEncodedFormData200ResponseBody"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An unknown error occurred, trying again might help.",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/UnexpectedError" }
+              }
+            }
+          }
+        }
       }
     },
     "/api/v2/route-with-query-params": {
@@ -405,8 +601,7 @@
               }
             }
           }
-        },
-        "tags": ["RPC"]
+        }
       }
     },
     "/api/v2/rpc/deleteTodo": {
@@ -438,8 +633,75 @@
               }
             }
           }
+        }
+      }
+    },
+    "/api/v2/rpc/formDataMultipart": {
+      "post": {
+        "operationId": "formDataMultipart",
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "$ref": "#/components/schemas/FormDataMultipartRequestBody"
+              }
+            }
+          }
         },
-        "tags": ["RPC"]
+        "responses": {
+          "200": {
+            "description": "FormDataMultipartResponseBody",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FormDataMultipartResponseBody"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "An unknown error occurred, trying again might help.",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/UnexpectedError" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v2/rpc/formDataUrlEncoded": {
+      "post": {
+        "operationId": "formDataUrlEncoded",
+        "requestBody": {
+          "content": {
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "$ref": "#/components/schemas/FormDataUrlEncodedRequestBody"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "FormDataUrlEncodedResponseBody",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FormDataUrlEncodedResponseBody"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "An unknown error occurred, trying again might help.",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/UnexpectedError" }
+              }
+            }
+          }
+        }
       }
     },
     "/api/v2/rpc/getTodoById": {
@@ -473,8 +735,7 @@
               }
             }
           }
-        },
-        "tags": ["RPC"]
+        }
       }
     },
     "/api/v2/rpc/getTodos": {
@@ -499,8 +760,7 @@
               }
             }
           }
-        },
-        "tags": ["RPC"]
+        }
       }
     },
     "/api/v2/todos": {
@@ -525,8 +785,7 @@
               }
             }
           }
-        },
-        "tags": ["example-api", "todos", "app-router"]
+        }
       },
       "post": {
         "operationId": "createTodo",
@@ -566,8 +825,7 @@
               }
             }
           }
-        },
-        "tags": ["example-api", "todos", "app-router"]
+        }
       }
     },
     "/api/v2/todos/{id}": {
@@ -610,8 +868,7 @@
             "required": true,
             "schema": { "type": "string" }
           }
-        ],
-        "tags": ["example-api", "todos", "app-router"]
+        ]
       },
       "delete": {
         "operationId": "deleteTodo",
@@ -652,8 +909,7 @@
             "required": true,
             "schema": { "type": "string" }
           }
-        ],
-        "tags": ["example-api", "todos", "app-router"]
+        ]
       }
     }
   },
@@ -690,6 +946,25 @@
         "type": "object",
         "properties": { "message": { "type": "string" } },
         "required": ["message"],
+        "additionalProperties": false
+      },
+      "FormDataMultipartRequestBody": {
+        "type": "object",
+        "properties": { "text": { "type": "string" }, "file": {} },
+        "required": ["text", "file"],
+        "additionalProperties": false
+      },
+      "FormDataMultipartResponseBody": { "type": "string", "format": "binary" },
+      "FormDataUrlEncodedRequestBody": {
+        "type": "object",
+        "properties": { "text": { "type": "string" } },
+        "required": ["text"],
+        "additionalProperties": false
+      },
+      "FormDataUrlEncodedResponseBody": {
+        "type": "object",
+        "properties": { "text": { "type": "string" } },
+        "required": ["text"],
         "additionalProperties": false
       },
       "GetQueryParams200ResponseBody": {
@@ -756,9 +1031,32 @@
           "additionalProperties": false
         }
       },
+      "MultipartFormData200ResponseBody": {
+        "type": "string",
+        "format": "binary"
+      },
+      "MultipartFormDataRequestBody": {
+        "type": "object",
+        "properties": {
+          "text": { "type": "string" },
+          "file": { "type": "string", "format": "binary" }
+        }
+      },
       "UnexpectedError": {
         "type": "object",
         "properties": { "message": { "type": "string" } },
+        "additionalProperties": false
+      },
+      "UrlEncodedFormData200ResponseBody": {
+        "type": "object",
+        "properties": { "text": { "type": "string" } },
+        "required": ["text"],
+        "additionalProperties": false
+      },
+      "UrlEncodedFormDataRequestBody": {
+        "type": "object",
+        "properties": { "text": { "type": "string" } },
+        "required": ["text"],
         "additionalProperties": false
       }
     }

--- a/apps/example/src/app/api/v2/form-data/multipart/route.ts
+++ b/apps/example/src/app/api/v2/form-data/multipart/route.ts
@@ -1,0 +1,53 @@
+import { TypedNextResponse, route, routeOperation } from 'next-rest-framework';
+import { multipartFormSchema } from '@/utils';
+import { z } from 'zod';
+
+export const runtime = 'edge';
+
+export const { POST } = route({
+  multipartFormData: routeOperation({
+    method: 'POST'
+  })
+    .input({
+      contentType: 'multipart/form-data',
+      body: multipartFormSchema, // A zod-form-data schema is required.
+      // The binary file cannot described with a Zod schema so we define it by hand for the OpenAPI spec.
+      bodySchema: {
+        type: 'object',
+        properties: {
+          text: {
+            type: 'string'
+          },
+          file: {
+            type: 'string',
+            format: 'binary'
+          }
+        }
+      }
+    })
+    .outputs([
+      {
+        status: 200,
+        contentType: 'application/octet-stream',
+        body: z.unknown(),
+        // The binary file cannot described with a Zod schema so we define it by hand for the OpenAPI spec.
+        bodySchema: {
+          type: 'string',
+          format: 'binary'
+        }
+      }
+    ])
+    .handler(async (req) => {
+      // const json = await req.json(); // Form can also be parsed as JSON.
+      const formData = await req.formData();
+      const file = formData.get('file');
+
+      return new TypedNextResponse(file, {
+        status: 200,
+        headers: {
+          'Content-Type': 'application/octet-stream',
+          'Content-Disposition': `attachment; filename="${file.name}"`
+        }
+      });
+    })
+});

--- a/apps/example/src/app/api/v2/form-data/url-encoded/route.ts
+++ b/apps/example/src/app/api/v2/form-data/url-encoded/route.ts
@@ -1,0 +1,30 @@
+import { formSchema } from '@/utils';
+import { TypedNextResponse, route, routeOperation } from 'next-rest-framework';
+
+export const runtime = 'edge';
+
+export const { POST } = route({
+  urlEncodedFormData: routeOperation({
+    method: 'POST'
+  })
+    .input({
+      contentType: 'application/x-www-form-urlencoded',
+      body: formSchema // A zod-form-data schema is required.
+    })
+    .outputs([
+      {
+        status: 200,
+        contentType: 'application/octet-stream',
+        body: formSchema
+      }
+    ])
+    .handler(async (req) => {
+      const { text } = await req.json();
+      // const formData = await req.formData(); // Form can also be parsed as form data.
+
+      // Type-checked response.
+      return TypedNextResponse.json({
+        text
+      });
+    })
+});

--- a/apps/example/src/app/api/v2/route-with-query-params/route.ts
+++ b/apps/example/src/app/api/v2/route-with-query-params/route.ts
@@ -1,28 +1,27 @@
 import { TypedNextResponse, route, routeOperation } from 'next-rest-framework';
 import { z } from 'zod';
 
-const schema = z.object({
+const querySchema = z.object({
   foo: z.string().uuid(),
   bar: z.string().optional(),
   baz: z.string()
 });
 
-export const dynamic = 'force-dynamic';
+export const runtime = 'edge';
 
-// Example app router route handler with query params.
 export const { GET } = route({
   getQueryParams: routeOperation({
     method: 'GET'
   })
     .input({
       contentType: 'application/json',
-      query: schema
+      query: querySchema
     })
     .outputs([
       {
         status: 200,
         contentType: 'application/json',
-        schema
+        body: querySchema
       }
     ])
     .handler((req) => {

--- a/apps/example/src/app/api/v2/route.ts
+++ b/apps/example/src/app/api/v2/route.ts
@@ -3,6 +3,5 @@ import { docsRoute } from 'next-rest-framework';
 export const runtime = 'edge';
 
 export const { GET } = docsRoute({
-  deniedPaths: ['/api/routes/third-party-endpoint'],
-  openApiJsonPath: '/openapi.json'
+  deniedPaths: ['/api/v2/third-party-endpoint', '/api/v1/third-party-endpoint']
 });

--- a/apps/example/src/app/api/v2/rpc/[operationId]/route.ts
+++ b/apps/example/src/app/api/v2/rpc/[operationId]/route.ts
@@ -1,4 +1,11 @@
-import { createTodo, deleteTodo, getTodoById, getTodos } from '@/actions';
+import {
+  createTodo,
+  deleteTodo,
+  getTodoById,
+  getTodos,
+  formDataUrlEncoded,
+  formDataMultipart
+} from '@/actions';
 import { rpcRoute } from 'next-rest-framework';
 
 export const runtime = 'edge';
@@ -7,7 +14,9 @@ export const { POST } = rpcRoute({
   getTodos,
   getTodoById,
   createTodo,
-  deleteTodo
+  deleteTodo,
+  formDataUrlEncoded,
+  formDataMultipart
 });
 
 export type RpcClient = typeof POST.client;

--- a/apps/example/src/app/api/v2/third-party-endpoint/route.ts
+++ b/apps/example/src/app/api/v2/third-party-endpoint/route.ts
@@ -4,8 +4,7 @@ export const runtime = 'edge';
 
 // You can still write regular routes with Next REST Framework.
 export const GET = () => {
-  return NextResponse.json('Server error', {
-    status: 500,
+  return NextResponse.json('Hello World!', {
     headers: { 'Content-Type': 'text/plain' }
   });
 };

--- a/apps/example/src/app/api/v2/todos/[id]/route.ts
+++ b/apps/example/src/app/api/v2/todos/[id]/route.ts
@@ -1,43 +1,27 @@
+import { MOCK_TODOS, todoSchema } from '@/utils';
 import { TypedNextResponse, route, routeOperation } from 'next-rest-framework';
 import { z } from 'zod';
 
-const TODOS = [
-  {
-    id: 1,
-    name: 'TODO 1',
-    completed: false
-  }
-];
-
 export const runtime = 'edge';
 
-// Example dynamic app router route handler with GET/DELETE handlers.
 export const { GET, DELETE } = route({
   getTodoById: routeOperation({
-    method: 'GET',
-    // Optional OpenAPI operation documentation.
-    openApiOperation: {
-      tags: ['example-api', 'todos', 'app-router']
-    }
+    method: 'GET'
   })
     .outputs([
       {
-        schema: z.object({
-          id: z.number(),
-          name: z.string(),
-          completed: z.boolean()
-        }),
+        body: todoSchema,
         status: 200,
         contentType: 'application/json'
       },
       {
-        schema: z.string(),
+        body: z.string(),
         status: 404,
         contentType: 'application/json'
       }
     ])
     .handler((_req, { params: { id } }) => {
-      const todo = TODOS.find((t) => t.id === Number(id));
+      const todo = MOCK_TODOS.find((t) => t.id === Number(id));
 
       if (!todo) {
         return TypedNextResponse.json('TODO not found.', {
@@ -51,33 +35,30 @@ export const { GET, DELETE } = route({
     }),
 
   deleteTodo: routeOperation({
-    method: 'DELETE',
-    // Optional OpenAPI operation documentation.
-    openApiOperation: {
-      tags: ['example-api', 'todos', 'app-router']
-    }
+    method: 'DELETE'
   })
     .outputs([
       {
-        schema: z.string(),
+        body: z.string(),
         status: 204,
         contentType: 'application/json'
       },
       {
-        schema: z.string(),
+        body: z.string(),
         status: 404,
         contentType: 'application/json'
       }
     ])
     .handler((_req, { params: { id } }) => {
-      // Delete todo.
-      const todo = TODOS.find((t) => t.id === Number(id));
+      const todo = MOCK_TODOS.find((t) => t.id === Number(id));
 
       if (!todo) {
         return TypedNextResponse.json('TODO not found.', {
           status: 404
         });
       }
+
+      // Delete todo.
 
       return TypedNextResponse.json('TODO deleted.', {
         status: 204

--- a/apps/example/src/app/api/v2/todos/route.ts
+++ b/apps/example/src/app/api/v2/todos/route.ts
@@ -4,72 +4,55 @@ import { z } from 'zod';
 
 export const runtime = 'edge';
 
-// Example app router route handler with GET/POST handlers.
 export const { GET, POST } = route({
   getTodos: routeOperation({
-    method: 'GET',
-    // Optional OpenAPI operation documentation.
-    openApiOperation: {
-      tags: ['example-api', 'todos', 'app-router']
-    }
+    method: 'GET'
   })
-    // Output schema for strictly-typed responses and OpenAPI documentation.
     .outputs([
       {
         status: 200,
         contentType: 'application/json',
-        schema: z.array(todoSchema)
+        body: z.array(todoSchema)
       }
     ])
     .handler(() => {
-      // Type-checked response.
       return TypedNextResponse.json(MOCK_TODOS, {
         status: 200
       });
     }),
 
   createTodo: routeOperation({
-    method: 'POST',
-    // Optional OpenAPI operation documentation.
-    openApiOperation: {
-      tags: ['example-api', 'todos', 'app-router']
-    }
+    method: 'POST'
   })
-    // Input schema for strictly-typed request, request validation and OpenAPI documentation.
     .input({
       contentType: 'application/json',
       body: z.object({
         name: z.string()
       })
     })
-    // Output schema for strictly-typed responses and OpenAPI documentation.
     .outputs([
       {
         status: 201,
         contentType: 'application/json',
-        schema: z.string()
+        body: z.string()
       },
       {
         status: 401,
         contentType: 'application/json',
-        schema: z.string()
+        body: z.string()
       }
     ])
-    .middleware(
-      // Optional middleware logic executed before request validation.
-      (req) => {
-        if (!req.headers.get('authorization')) {
-          // Type-checked response.
-          return TypedNextResponse.json('Unauthorized', {
-            status: 401
-          });
-        }
+    // Optional middleware logic executed before request validation.
+    .middleware((req) => {
+      if (!req.headers.get('very-secure')) {
+        return TypedNextResponse.json('Unauthorized', {
+          status: 401
+        });
       }
-    )
+    })
     .handler(async (req) => {
-      const { name } = await req.json(); // Strictly-typed request.
+      const { name } = await req.json();
 
-      // Type-checked response.
       return TypedNextResponse.json(`New TODO created: ${name}`, {
         status: 201
       });

--- a/apps/example/src/pages/api/v1/form-data/multipart/index.ts
+++ b/apps/example/src/pages/api/v1/form-data/multipart/index.ts
@@ -1,0 +1,70 @@
+import { multipartFormSchema } from '@/utils';
+import { z } from 'zod';
+import { apiRoute, apiRouteOperation } from 'next-rest-framework';
+
+// Body parser must be disabled when parsing multipart/form-data requests with pages router.
+export const config = {
+  api: {
+    bodyParser: false
+  }
+};
+
+export default apiRoute({
+  multipartFormData: apiRouteOperation({
+    method: 'POST'
+  })
+    .input({
+      contentType: 'multipart/form-data',
+      body: multipartFormSchema, // A zod-form-data schema is required.
+      // The binary file cannot described with a Zod schema so we define it by hand for the OpenAPI spec.
+      bodySchema: {
+        type: 'object',
+        properties: {
+          text: {
+            type: 'string'
+          },
+          file: {
+            type: 'string',
+            format: 'binary'
+          }
+        }
+      }
+    })
+    .outputs([
+      {
+        status: 200,
+        contentType: 'application/octet-stream',
+        body: z.unknown(),
+        // The binary file cannot described with a Zod schema so we define it by hand for the OpenAPI spec.
+        bodySchema: {
+          type: 'string',
+          format: 'binary'
+        }
+      }
+    ])
+    .handler(async (req, res) => {
+      const formData = req.body;
+      const file = formData.get('file');
+      const reader = file.stream().getReader();
+      res.setHeader('Content-Type', 'application/octet-stream');
+
+      res.setHeader(
+        'Content-Disposition',
+        `attachment; filename="${file.name}"`
+      );
+
+      const pump = async () => {
+        await reader.read().then(async ({ done, value }) => {
+          if (done) {
+            res.end();
+            return;
+          }
+
+          res.write(value);
+          await pump();
+        });
+      };
+
+      await pump();
+    })
+});

--- a/apps/example/src/pages/api/v1/form-data/url-encoded/index.ts
+++ b/apps/example/src/pages/api/v1/form-data/url-encoded/index.ts
@@ -1,0 +1,26 @@
+import { formSchema } from '@/utils';
+import { apiRoute, apiRouteOperation } from 'next-rest-framework';
+
+export default apiRoute({
+  urlEncodedFormData: apiRouteOperation({
+    method: 'POST'
+  })
+    .input({
+      contentType: 'application/x-www-form-urlencoded',
+      body: formSchema // A zod-form-data schema is required.
+    })
+    .outputs([
+      {
+        status: 200,
+        contentType: 'application/json',
+        body: formSchema
+      }
+    ])
+    .handler((req, res) => {
+      const formData = req.body;
+
+      res.json({
+        text: formData.get('text')
+      });
+    })
+});

--- a/apps/example/src/pages/api/v1/index.ts
+++ b/apps/example/src/pages/api/v1/index.ts
@@ -1,8 +1,7 @@
 import { docsApiRoute } from 'next-rest-framework';
 
 export default docsApiRoute({
-  deniedPaths: ['/api/routes/third-party-endpoint'],
-  openApiJsonPath: '/openapi.json',
+  deniedPaths: ['/api/v2/third-party-endpoint', '/api/v1/third-party-endpoint'], // Ignore endpoints from the generated OpenAPI spec.
   docsConfig: {
     provider: 'swagger-ui'
   }

--- a/apps/example/src/pages/api/v1/route-with-query-params/index.ts
+++ b/apps/example/src/pages/api/v1/route-with-query-params/index.ts
@@ -1,26 +1,25 @@
 import { apiRoute, apiRouteOperation } from 'next-rest-framework';
 import { z } from 'zod';
 
-const schema = z.object({
+const querySchema = z.object({
   foo: z.string().uuid(),
   bar: z.string().optional(),
   baz: z.string()
 });
 
-// Example pages router API route handler with query params.
 export default apiRoute({
   getQueryParams: apiRouteOperation({
     method: 'GET'
   })
     .input({
       contentType: 'application/json',
-      query: schema
+      query: querySchema
     })
     .outputs([
       {
         status: 200,
         contentType: 'application/json',
-        schema
+        body: querySchema
       }
     ])
     .handler((req, res) => {

--- a/apps/example/src/pages/api/v1/rpc/[operationId].ts
+++ b/apps/example/src/pages/api/v1/rpc/[operationId].ts
@@ -1,11 +1,20 @@
-import { createTodo, deleteTodo, getTodoById, getTodos } from '@/actions';
+import {
+  createTodo,
+  deleteTodo,
+  getTodoById,
+  getTodos,
+  formDataUrlEncoded,
+  formDataMultipart
+} from '@/actions';
 import { rpcApiRoute } from 'next-rest-framework';
 
 const handler = rpcApiRoute({
   getTodos,
   getTodoById,
   createTodo,
-  deleteTodo
+  deleteTodo,
+  formDataUrlEncoded,
+  formDataMultipart
 });
 
 export type RpcClient = typeof handler.client;

--- a/apps/example/src/pages/api/v1/third-party-endpoint/index.ts
+++ b/apps/example/src/pages/api/v1/third-party-endpoint/index.ts
@@ -1,0 +1,9 @@
+import { type NextApiRequest, type NextApiResponse } from 'next';
+
+// You can still write regular API routes with Next REST Framework.
+const handler = (_req: NextApiRequest, res: NextApiResponse) => {
+  res.setHeader('Content-Type', 'text/plain');
+  res.json('Hello  World!');
+};
+
+export default handler;

--- a/apps/example/src/pages/api/v1/todos/[id].ts
+++ b/apps/example/src/pages/api/v1/todos/[id].ts
@@ -1,21 +1,10 @@
+import { MOCK_TODOS, todoSchema } from '@/utils';
 import { apiRoute, apiRouteOperation } from 'next-rest-framework';
 import { z } from 'zod';
 
-const TODOS = [
-  {
-    id: 1,
-    name: 'TODO 1',
-    completed: false
-  }
-];
-
-// Example dynamic pages router API route with GET/DELETE handlers.
 export default apiRoute({
   getTodoById: apiRouteOperation({
-    method: 'GET',
-    openApiOperation: {
-      tags: ['example-api', 'todos', 'pages-router']
-    }
+    method: 'GET'
   })
     .input({
       query: z.object({
@@ -24,22 +13,18 @@ export default apiRoute({
     })
     .outputs([
       {
-        schema: z.object({
-          id: z.number(),
-          name: z.string(),
-          completed: z.boolean()
-        }),
+        body: todoSchema,
         status: 200,
         contentType: 'application/json'
       },
       {
-        schema: z.string(),
+        body: z.string(),
         status: 404,
         contentType: 'application/json'
       }
     ])
     .handler((req, res) => {
-      const todo = TODOS.find((t) => t.id === Number(req.query.id));
+      const todo = MOCK_TODOS.find((t) => t.id === Number(req.query.id));
 
       if (!todo) {
         res.status(404).json('TODO not found.');
@@ -50,10 +35,7 @@ export default apiRoute({
     }),
 
   deleteTodo: apiRouteOperation({
-    method: 'DELETE',
-    openApiOperation: {
-      tags: ['example-api', 'todos', 'pages-router']
-    }
+    method: 'DELETE'
   })
     .input({
       query: z.object({
@@ -62,24 +44,24 @@ export default apiRoute({
     })
     .outputs([
       {
-        schema: z.string(),
+        body: z.string(),
         status: 204,
         contentType: 'application/json'
       },
       {
-        schema: z.string(),
+        body: z.string(),
         status: 404,
         contentType: 'application/json'
       }
     ])
     .handler((req, res) => {
-      // Delete todo.
-      const todo = TODOS.find((t) => t.id === Number(req.query.id));
+      const todo = MOCK_TODOS.find((t) => t.id === Number(req.query.id));
 
       if (!todo) {
         res.status(404).json('TODO not found.');
       }
 
+      // Delete the todo.
       res.status(204).json('TODO deleted.');
     })
 });

--- a/apps/example/src/pages/api/v1/todos/index.ts
+++ b/apps/example/src/pages/api/v1/todos/index.ts
@@ -1,77 +1,52 @@
+import { MOCK_TODOS, todoSchema } from '@/utils';
 import { apiRoute, apiRouteOperation } from 'next-rest-framework';
 import { z } from 'zod';
 
-const TODOS = [
-  {
-    id: 1,
-    name: 'TODO 1',
-    completed: false
-  }
-];
-
-// Example pages router API route with GET/POST handlers.
 export default apiRoute({
   getTodos: apiRouteOperation({
-    method: 'GET',
-    // Optional OpenAPI operation documentation.
-    openApiOperation: {
-      tags: ['example-api', 'todos', 'pages-router']
-    }
+    method: 'GET'
   })
-    // Output schema for strictly-typed responses and OpenAPI documentation.
     .outputs([
       {
         status: 200,
         contentType: 'application/json',
-        schema: z.array(
-          z.object({
-            id: z.number(),
-            name: z.string(),
-            completed: z.boolean()
-          })
-        )
+        body: z.array(todoSchema)
       }
     ])
     .handler((_req, res) => {
-      // Type-checked response.
-      res.status(200).json(TODOS);
+      res.status(200).json(MOCK_TODOS);
     }),
 
   createTodo: apiRouteOperation({
-    method: 'POST',
-    // Optional OpenAPI operation documentation.
-    openApiOperation: {
-      tags: ['example-api', 'todos', 'pages-router']
-    }
+    method: 'POST'
   })
-    // Input schema for strictly-typed request, request validation and OpenAPI documentation.
     .input({
       contentType: 'application/json',
       body: z.object({
         name: z.string()
       })
     })
-    // Output schema for strictly-typed responses and OpenAPI documentation.
     .outputs([
       {
         status: 201,
         contentType: 'application/json',
-        schema: z.string()
+        body: z.string()
       },
       {
         status: 401,
         contentType: 'application/json',
-        schema: z.string()
+        body: z.string()
       }
     ])
     // Optional middleware logic executed before request validation.
     .middleware((req, res) => {
-      if (!req.headers.authorization) {
-        res.status(401).json('Unauthorized'); // Type-checked response.
+      if (!req.headers['very-secure']) {
+        res.status(401).json('Unauthorized');
       }
     })
     .handler((req, res) => {
-      const { name } = req.body; // Strictly-typed request.
-      res.status(201).json(`New TODO created: ${name}`); // Type-checked response.
+      const { name } = req.body;
+      // Create a new TODO.
+      res.status(201).json(`New TODO created: ${name}`);
     })
 });

--- a/apps/example/src/utils.ts
+++ b/apps/example/src/utils.ts
@@ -1,9 +1,19 @@
 import { z } from 'zod';
+import { zfd } from 'zod-form-data';
 
 export const todoSchema = z.object({
   id: z.number(),
   name: z.string(),
   completed: z.boolean()
+});
+
+export const formSchema = zfd.formData({
+  text: zfd.text()
+});
+
+export const multipartFormSchema = zfd.formData({
+  text: zfd.text(),
+  file: zfd.file() // In development with Edge runtime this won't work: https://github.com/vercel/next.js/issues/38184
 });
 
 export type Todo = z.infer<typeof todoSchema>;

--- a/docs/docs/api-reference.md
+++ b/docs/docs/api-reference.md
@@ -33,16 +33,11 @@ The docs config options can be used to customize the generated docs:
 
 #### [Route handler options](#route-handler-options)
 
-The following options can be passed to the `routeHandler` (app router) and `apiRouteHandler` (pages router) functions to create new API endpoints:
-
-| Name                                                       | Description                                                                                                                                                 | Required |
-| ---------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- |
-| `GET \| PUT \| POST \| DELETE \| OPTIONS \| HEAD \| PATCH` | A [Method handler](#method-handlers) object.                                                                                                                | `true`   |
-| `openApiPath`                                              | An OpenAPI [Path Item Object](https://swagger.io/specification/#path-item-object) that can be used to override and extend the auto-generated specification. | `false`  |
+The `routeHandler` (app router) and `apiRouteHandler` (pages router) functions allow you to pass an object as the second parameter, where you can define a property called `openApiPath`. This property is an OpenAPI [Path Item Object](https://swagger.io/specification/#path-item-object) that can be used to override and extend the auto-generated specification for the given route.
 
 #### [Route operations](#route-operations)
 
-The route operation functions `routeOperation` (app router) and `apiRouteOperation` (pages router) allow you to define your API handlers for your endpoints. These functions accept an OpenAPI [Operation object](https://swagger.io/specification/#operation-object) as a parameter, that can be used to override the auto-generated specification. Calling this function allows you to chain your API handler logic with the following functions:
+The route operation functions `routeOperation` (app router) and `apiRouteOperation` (pages router) allow you to define your method handlers for your endpoints. These functions require you to pass an object where you will define the method for the given operation, as well as optionally a property called `openApiOperation`. This property is an OpenAPI [Operation object](https://swagger.io/specification/#operation-object) that can be used to override and extend the auto-generated specification for the given operation. Calling the `routeOperation` and `apiRouteOperation` functions allows you to chain your API handler logic with the following functions:
 
 | Name         | Description                                                                                                                                                                                                                                                          |
 | ------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -55,11 +50,14 @@ The route operation functions `routeOperation` (app router) and `apiRouteOperati
 
 The route operation input function is used for type-checking, validation and documentation of the request, taking in an object with the following properties:
 
-| Name          | Description                                                                                                                                                                                            | Required |
-| ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | -------- |
-| `contentType` | The content type header of the request. When the content type is defined, a request with an incorrect content type header will get an error response.                                                  | `false`  |
-| `body`        | A [Zod](https://github.com/colinhacks/zod) schema describing the format of the request body. When the body schema is defined, a request with an invalid request body will get an error response.       | `false`  |
-| `query`       | A [Zod](https://github.com/colinhacks/zod) schema describing the format of the query parameters. When the query schema is defined, a request with invalid query parameters will get an error response. | `false`  |
+| Name          | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                            | Required |
+| ------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- |
+| `contentType` | The content type header of the request. When the content type is defined, a request with an incorrect content type header will get an error response.                                                                                                                                                                                                                                                                                                                  | `false`  |
+| `body`        | A [Zod](https://github.com/colinhacks/zod) schema describing the format of the request body. When using `application/x-www-form-urlencoded` or `multipart/form-data` content types, this should be a `zod-form-data` schema instead. When the body schema is defined, a request with an invalid request body will get an error response. The request body is parsed using this schema and updated to the request if valid, so the body should always match the schema. | `false`  |
+| `bodySchema`  | A JSON schema that you can provide in case the conversion of the `body` Zod schema fails or produces an incorrect result in your OpenAPI spec.                                                                                                                                                                                                                                                                                                                         | `false`  |
+| `query`       | A [Zod](https://github.com/colinhacks/zod) schema describing the format of the query parameters. When the query schema is defined, a request with invalid query parameters will get an error response. Query parameters are parsed using this schema and updated to the request if valid, so the query parameters from the request should always match the schema.                                                                                                     | `false`  |
+| `querySchema` | A JSON schema that you can provide in case the conversion of the `query` Zod schema fails or produces an incorrect result in your OpenAPI spec.                                                                                                                                                                                                                                                                                                                        | `false`  |
+| `params`      | A [Zod](https://github.com/colinhacks/zod) schema describing the format of the path parameters for strong typing when using them in your route handler.                                                                                                                                                                                                                                                                                                                | `false`  |
 
 Calling the route operation input function allows you to chain your API handler logic with the [Route operation outputs](#route-operation-outputs), [Route operation middleware](#route-operation-middleware) and [Route operation handler](#route-operation-handler) functions.
 
@@ -67,29 +65,31 @@ Calling the route operation input function allows you to chain your API handler 
 
 The route operation outputs function is used for type-checking and documentation of the response, taking in an array of objects with the following properties:
 
-| Name          | Description                                                                                   | Required |
-| ------------- | --------------------------------------------------------------------------------------------- | -------- |
-| `status`      | A status code that your API can return.                                                       | `true`   |
-| `contentType` | The content type header of the response.                                                      | `true`   |
-| `schema`      | A [Zod](https://github.com/colinhacks/zod) schema describing the format of the response data. |  `true`  |
+| Name          | Description                                                                                                                                    | Required |
+| ------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- | -------- |
+| `status`      | A status code that your API can return.                                                                                                        | `true`   |
+| `contentType` | The content type header of the response.                                                                                                       | `true`   |
+| `body`        | A [Zod](https://github.com/colinhacks/zod) (or `zod-form-data`) schema describing the format of the response data.                             |  `true`  |
+| `bodySchema`  | A JSON schema that you can provide in case the conversion of the `body` Zod schema fails or produces an incorrect result in your OpenAPI spec. | `false`  |
+| `name`        | An optional name used in the generated OpenAPI spec for the response body, e.g. `GetTodosSuccessResponse`.                                     | `false`  |
 
 Calling the route operation outputs function allows you to chain your API handler logic with the [Route operation middleware](#route-operation-middleware) and [Route operation handler](#route-operation-handler) functions.
 
 ##### [Route operation middleware](#route-operation-middleware)
 
-The route operation middleware function is executed before validating the request input. The function takes in the same parameters as the Next.js [router handlers](https://nextjs.org/docs/app/building-your-application/routing/route-handlers) and [API routes](https://nextjs.org/docs/pages/building-your-application/routing/api-routes) handlers. Additionally, as a second parameter this function takes the return value of your last middleware function, defaulting to an empty object. Throwing an error inside a middleware function will stop the execution of the handler and you can also return a custom response like you would do within the [Handler](#handler) function. Calling the route operation middleware function allows you to chain your API handler logic with the [Handler](#handler) function. Alternatively, you may chain up to three middleware functions together:
+The route operation middleware function is executed before validating the request input. The function takes in the same parameters as the Next.js [router handler](https://nextjs.org/docs/app/building-your-application/routing/route-handlers) (app router) and [API route](https://nextjs.org/docs/pages/building-your-application/routing/api-routes) (pages router) functions. Additionally, as a second parameter this function takes the return value of your last middleware function, defaulting to an empty object. Throwing an error inside a middleware function will stop the execution of the handler and you can also return a custom response like you would do within the [Route operation handler](#route-operation-handler) function. Calling the route operation middleware function allows you to chain your API handler logic with the [Route operation handler](#route-operation-handler) function. Alternatively, you may chain up to three middleware functions together:
 
 ```typescript
-// ...
-const handler = route({
-  getTodos: routeOperation()
+// App router.
+export const { GET } = route({
+  getTodos: routeOperation({ method: 'GET' })
     .middleware(() => {
       return { foo: 'bar' };
     })
     .middleware((_req, _ctx, { foo }) => {
-      // if (myCondition) {
-      //   return NextResponse.json({ error: 'My error.' });
-      // }
+      if (myCondition) {
+        return NextResponse.json({ error: 'My error.' }, { status: 400 });
+      }
 
       return {
         foo,
@@ -100,34 +100,43 @@ const handler = route({
       // ...
     })
 });
+
+// Pages router.
+export default apiRoute({
+  getTodos: routeOperation({ method: 'GET' })
+    .middleware(() => {
+      return { foo: 'bar' };
+    })
+    .middleware((req, res, { foo }) => {
+      if (myCondition) {
+        res.status(400).json({ error: 'My error.' });
+        return;
+      }
+
+      return {
+        foo,
+        bar: 'baz'
+      };
+    })
+    .handler((req, res, { foo, bar }) => {
+      // ...
+    })
+});
 ```
 
 ##### [Route operation handler](#route-operation-handler)
 
-The route operation handler function is a strongly-typed function to implement the business logic for your API. The function takes in strongly-typed versions of the same parameters as the Next.js [router handlers](https://nextjs.org/docs/app/building-your-application/routing/route-handlers) and [API routes](https://nextjs.org/docs/pages/building-your-application/routing/api-routes) handlers. Additionally, as a third parameter this function takes the return value of your last middleware function:
-
-```typescript
-// ...
-const handler = route({
-  getTodos: routeOperation()
-    .middleware(() => {
-      return { foo: "bar" };
-    })
-    .handler((_req, _ctx, { foo }) => {
-      // ...
-    });
-});
-```
+The route operation handler function is a strongly-typed function to implement the business logic for your API. The function takes in strongly-typed versions of the same parameters as the Next.js [router handler](https://nextjs.org/docs/app/building-your-application/routing/route-handlers) (app router) and [API route](https://nextjs.org/docs/pages/building-your-application/routing/api-routes) (pages router) functions. Additionally, as a third parameter this function takes the return value of your last middleware function (see above), defaulting to an empty object.
 
 ### RPC
 
 #### [RPC route handler options](#rpc-route-handler-options)
 
-The `rpcRouteHandler` (app router) and `rpcApiRouteHandler` (pages router) functions allow you to define your API handlers for your RPC endpoints. These functions accept an OpenAPI [Operation object](https://swagger.io/specification/#operation-object) as a parameter, that can be used to override the auto-generated specification.
+The `rpcRouteHandler` (app router) and `rpcApiRouteHandler` (pages router) functions allow you to pass an object as the second parameter, where you can define a property called `openApiPath`. This property is an OpenAPI [Path Item Object](https://swagger.io/specification/#path-item-object) that can be used to override and extend the auto-generated specification for the given route.
 
 #### [RPC operations](#rpc-operations)
 
-The `rpcOperation` function allows you to define your API handlers for your RPC endpoint. Calling this function allows you to chain your API handler logic with the following functions.
+The `rpcOperation` function allows you to define your API handlers for your RPC endpoint. This function allows you to pass an OpenAPI [Operation object](https://swagger.io/specification/#operation-object) as a parameter, that can be used to override and extend the auto-generated specification for the given operation. Calling this function allows you to chain your API handler logic with the following functions.
 
 | Name         | Description                                                                                                                                                                                                                                                         |
 | ------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -138,7 +147,13 @@ The `rpcOperation` function allows you to define your API handlers for your RPC 
 
 ##### [RPC operation input](#rpc-operation-input)
 
-The RPC operation input function is used for type-checking, validation and documentation of the RPC call. It takes in a A [Zod](https://github.com/colinhacks/zod) schema as a parameter that describes the format of the operation input. When the input schema is defined, an RPC call with invalid input will get an error response.
+The RPC operation input function is used for type-checking, validation and documentation of the RPC call, taking in an object with the following properties:
+
+| Name          | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                            | Required |
+| ------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- |
+| `contentType` | The content type header of the request, limited to `application/json`, `application/x-www-form-urlencoded` and `multipart/form-data`. When the content type is defined, a request with an incorrect content type header will get an error response.                                                                                                                                                                                                                    | `false`  |
+| `body`        | A [Zod](https://github.com/colinhacks/zod) schema describing the format of the request body. When using `application/x-www-form-urlencoded` or `multipart/form-data` content types, this should be a `zod-form-data` schema instead. When the body schema is defined, a request with an invalid request body will get an error response. The request body is parsed using this schema and updated to the request if valid, so the body should always match the schema. | `false`  |
+| `bodySchema`  | A JSON schema that you can provide in case the conversion of the `body` Zod schema fails or produces an incorrect result in your OpenAPI spec.                                                                                                                                                                                                                                                                                                                         | `false`  |
 
 Calling the RPC input function allows you to chain your API handler logic with the [RPC operation outputs](#rpc-operation-outputs), [RPC middleware](#rpc-operation-middleware) and [RPC handler](#rpc-operation-handler) functions.
 
@@ -146,10 +161,11 @@ Calling the RPC input function allows you to chain your API handler logic with t
 
 The RPC operation outputs function is used for type-checking and documentation of the response, taking in an array of objects with the following properties:
 
-| Name     | Description                                                                                   | Required |
-| -------- | --------------------------------------------------------------------------------------------- | -------- |
-| `schema` | A [Zod](https://github.com/colinhacks/zod) schema describing the format of the response data. |  `true`  |
-| `name`   | An optional name used in the generated OpenAPI spec, e.g. `GetTodosErrorResponse`.            | `false`  |
+| Name         | Description                                                                                                                                    | Required |
+| ------------ | ---------------------------------------------------------------------------------------------------------------------------------------------- | -------- |
+| `body`       | A [Zod](https://github.com/colinhacks/zod) (or `zod-form-data`) schema describing the format of the response data.                             |  `true`  |
+| `bodySchema` | A JSON schema that you can provide in case the conversion of the `body` Zod schema fails or produces an incorrect result in your OpenAPI spec. | `false`  |
+| `name`       | An optional name used in the generated OpenAPI spec for the response body, e.g. `GetTodosSuccessResponse`.                                     | `false`  |
 
 Calling the RPC operation outputs function allows you to chain your API handler logic with the [RPC operation middleware](#rpc-operation-middleware) and [RPC operation handler](#rpc-operation-handler) functions.
 
@@ -158,16 +174,16 @@ Calling the RPC operation outputs function allows you to chain your API handler 
 The RPC operation middleware function is executed before validating RPC operation input. The function takes in strongly typed parameters typed by the [RPC operation input](#rpc-operation-input) function. Additionally, as a second parameter this function takes the return value of your last middleware function, defaulting to an empty object. Throwing an error inside a middleware function will stop the execution of the handler. Calling the RPC operation middleware function allows you to chain your RPC API handler logic with the [RPC operation handler](#rpc-operation-handler) function. Alternatively, you may chain up to three middleware functions together:
 
 ```typescript
-// ...
-const handler = rpcRoute({
+// App router.
+export const { POST } = rpcRoute({
   getTodos: rpcOperation()
     .middleware(() => {
       return { foo: 'bar' };
     })
     .middleware((_input, { foo }) => {
-      // if (myCondition) {
-      //   throw Error('My error.')
-      // }
+      if (myCondition) {
+        throw Error('My error.');
+      }
 
       return {
         foo,
@@ -178,24 +194,16 @@ const handler = rpcRoute({
       // ...
     })
 });
+
+// Pages router.
+export default rpcApiRoute({
+  // ... Same as above.
+});
 ```
 
 ##### [RPC operation handler](#rpc-operation-handler)
 
-The RPC operation handler function is a strongly-typed function to implement the business logic for your API. The function takes in strongly typed parameters typed by the [RPC operation input](#rpc-operation-input) function. Additionally, as a second parameter this function takes the return value of your last middleware function:
-
-```typescript
-// ...
-const handler = rpcApiRoute({
-  getTodos: rpcOperation()
-    .middleware(() => {
-      return { foo: "bar" };
-    })
-    .handler((_input, { foo }) => {
-      // ...
-    });
-});
-```
+The RPC operation handler function is a strongly-typed function to implement the business logic for your API. The function takes in strongly typed parameters typed by the [RPC operation input](#rpc-operation-input) function. Additionally, as a second parameter this function takes the return value of your last middleware function (see above), defaulting to an empty object.
 
 ## [CLI](#cli)
 

--- a/docs/docs/getting-started.md
+++ b/docs/docs/getting-started.md
@@ -6,11 +6,14 @@ sidebar_position: 2
 
 ## Requirements
 
-In order to use Next REST Framework you need to have a Next.js project with the following dependencies installed:
+- Node.js v18.x. If you have an API using `File` or `FormData` web APIs, you might need Node v20.x, see: https://github.com/vercel/next.js/discussions/56032
+
+You also need the following dependencies installed in you Next.js project:
 
 - [Next.js](https://github.com/vercel/next.js) >= v12
 - [Zod](https://github.com/colinhacks/zod) >= v3
 - [TypeScript](https://www.typescriptlang.org/) >= v3
+- Optional, needed if working with forms: [zod-form-data](https://www.npmjs.com/package/zod-form-data) >= v2
 
 ## [Installation](#installation)
 
@@ -25,26 +28,48 @@ To get access to the auto-generated documentation, initialize the docs endpoint 
 #### [App router docs route](#app-router-docs-route):
 
 ```typescript
-// src/app/api/route.ts
-
-// export const runtime = 'edge'; // Edge runtime is supported.
+// src/app/api/v2/route.ts
 
 import { docsRoute } from 'next-rest-framework';
 
-export const { GET } = docsRoute();
+// export const runtime = 'edge'; // Edge runtime is supported.
+
+export const { GET } = docsRoute({
+  // deniedPaths: [...] // Ignore endpoints from the generated OpenAPI spec.
+  // allowedPaths: [...], // Explicitly set which endpoints to include in the generated OpenAPI spec.
+  // Override and customize the generated OpenAPI spec.
+  openApiObject: {
+    info: {
+      title: 'My API',
+      version: '1.0.0',
+      description: 'My API description.'
+    }
+    // ...
+  },
+  // openApiJsonPath: '/openapi.json', // Customize the path where the OpenAPI spec will be generated.
+  // Customize the rendered documentation.
+  docsConfig: {
+    provider: 'redoc', // redoc | swagger-ui
+    title: 'My API',
+    description: 'My API description.'
+    // ...
+  }
+});
 ```
 
 #### [Pages router docs API route](#pages-router-docs-api-route):
 
 ```typescript
-// src/pages/api.ts
+// src/pages/api/v1/index.ts
 
 import { docsApiRoute } from 'next-rest-framework';
 
-export default docsApiRoute();
+export default docsApiRoute({
+  // See configuration options from above.
+});
 ```
 
-This is enough to get you started. Now you can access the API documentation in your browser. Running `npx next-rest-framework generate` in the project root will generate the `openapi.json` OpenAPI specification file, located in the `public` folder. You can create multiple docs endpoints if needed and specify which config to use for the [CLI](#cli). See the full configuration options of this endpoint in the [Docs handler options](#docs-handler-options) section.
+This is enough to get you started. Now you can access the API documentation in your browser. Running `npx next-rest-framework generate` in the project root will generate the `openapi.json` OpenAPI specification file, located in the `public` folder by default. You can create multiple docs endpoints if needed and specify which config to use for the [CLI](#cli). See the full configuration options of this endpoint in the [Docs handler options](#docs-handler-options) section.
 
 ### [Create endpoint](#create-endpoint)
 
@@ -53,93 +78,77 @@ This is enough to get you started. Now you can access the API documentation in y
 ##### [App router route](#app-router-route):
 
 ```typescript
-// src/app/api/todos/route.ts
+// src/app/api/v2/todos/route.ts
 
 import { TypedNextResponse, route, routeOperation } from 'next-rest-framework';
 import { z } from 'zod';
 
-const TODOS = [
+// export const runtime = 'edge'; // Edge runtime is supported.
+
+const MOCK_TODOS = [
   {
     id: 1,
     name: 'TODO 1',
     completed: false
   }
+  // ...
 ];
 
-// export const runtime = 'edge'; // Edge runtime is supported.
+const todoSchema = z.object({
+  id: z.number(),
+  name: z.string(),
+  completed: z.boolean()
+});
 
-// Example app router route handler with GET/POST handlers.
 export const { GET, POST } = route({
   getTodos: routeOperation({
-    method: 'GET',
-    // Optional OpenAPI operation documentation.
-    openApiOperation: {
-      tags: ['example-api', 'todos', 'app-router']
-    }
+    method: 'GET'
   })
-    // Output schema for strictly-typed responses and OpenAPI documentation.
     .outputs([
       {
         status: 200,
         contentType: 'application/json',
-        schema: z.array(
-          z.object({
-            id: z.number(),
-            name: z.string(),
-            completed: z.boolean()
-          })
-        )
+        body: z.array(todoSchema)
       }
     ])
     .handler(() => {
-      // Type-checked response.
-      return TypedNextResponse.json(TODOS, {
+      return TypedNextResponse.json(MOCK_TODOS, {
         status: 200
       });
     }),
 
   createTodo: routeOperation({
-    method: 'POST',
-    // Optional OpenAPI operation documentation.
-    openApiOperation: {
-      tags: ['example-api', 'todos', 'app-router']
-    }
+    method: 'POST'
   })
-    // Input schema for strictly-typed request, request validation and OpenAPI documentation.
     .input({
       contentType: 'application/json',
       body: z.object({
         name: z.string()
       })
     })
-    // Output schema for strictly-typed responses and OpenAPI documentation.
     .outputs([
       {
         status: 201,
         contentType: 'application/json',
-        schema: z.string()
+        body: z.string()
       },
       {
         status: 401,
         contentType: 'application/json',
-        schema: z.string()
+        body: z.string()
       }
     ])
-    .middleware(
-      // Optional middleware logic executed before request validation.
-      (req) => {
-        if (!req.headers.get('authorization')) {
-          // Type-checked response.
-          return TypedNextResponse.json('Unauthorized', {
-            status: 401
-          });
-        }
+    // Optional middleware logic executed before request validation.
+    .middleware((req) => {
+      if (!req.headers.get('very-secure')) {
+        return TypedNextResponse.json('Unauthorized', {
+          status: 401
+        });
       }
-    )
+    })
     .handler(async (req) => {
-      const { name } = await req.json(); // Strictly-typed request.
+      const { name } = await req.json();
 
-      // Type-checked response.
       return TypedNextResponse.json(`New TODO created: ${name}`, {
         status: 201
       });
@@ -147,7 +156,7 @@ export const { GET, POST } = route({
 });
 ```
 
-The `TypedNextResponse` ensures that the response status codes and content-type headers are type-checked. You can still use the regular `NextResponse` if you prefer to have less type-safety.
+The `TypedNextResponse` ensures that the response status codes and content-type headers are type-checked against the defined outputs. You can still use the regular `NextResponse` if you prefer to have less type-safety.
 
 When using the default `nodejs` runtime with app router routes (`docsRoute` or `route`), you may encounter the [Dynamic server usage](https://nextjs.org/docs/messages/dynamic-server-error) Next.js error when running `next build`. In that case you should force the route to be dynamically rendered with the [dynamic](https://nextjs.org/docs/app/api-reference/file-conventions/route-segment-config#dynamic) option:
 
@@ -158,111 +167,18 @@ export const dynamic = 'force-dynamic';
 ##### [Pages router API route](#pages-router-api-route):
 
 ```typescript
-// src/pages/api/todos.ts
+// src/pages/api/v1/todos/index.ts
 
 import { apiRoute, apiRouteOperation } from 'next-rest-framework';
 import { z } from 'zod';
 
-const TODOS = [
+const MOCK_TODOS = [
   {
     id: 1,
     name: 'TODO 1',
     completed: false
   }
-];
-
-// Example pages router API route with GET/POST handlers.
-export default apiRoute({
-  getTodos: apiRouteOperation({
-    method: 'GET',
-    // Optional OpenAPI operation documentation.
-    openApiOperation: {
-      tags: ['example-api', 'todos', 'pages-router']
-    }
-  })
-    // Output schema for strictly-typed responses and OpenAPI documentation.
-    .outputs([
-      {
-        status: 200,
-        contentType: 'application/json',
-        schema: z.array(
-          z.object({
-            id: z.number(),
-            name: z.string(),
-            completed: z.boolean()
-          })
-        )
-      }
-    ])
-    .handler((_req, res) => {
-      // Type-checked response.
-      res.status(200).json(TODOS);
-    }),
-
-  createTodo: apiRouteOperation({
-    method: 'POST',
-    // Optional OpenAPI operation documentation.
-    openApiOperation: {
-      tags: ['example-api', 'todos', 'pages-router']
-    }
-  })
-    // Input schema for strictly-typed request, request validation and OpenAPI documentation.
-    .input({
-      contentType: 'application/json',
-      body: z.object({
-        name: z.string()
-      })
-    })
-    // Output schema for strictly-typed responses and OpenAPI documentation.
-    .outputs([
-      {
-        status: 201,
-        contentType: 'application/json',
-        schema: z.string()
-      },
-      {
-        status: 401,
-        contentType: 'application/json',
-        schema: z.string()
-      }
-    ])
-    // Optional middleware logic executed before request validation.
-    .middleware((req, res) => {
-      if (!req.headers.authorization) {
-        res.status(401).json('Unauthorized'); // Type-checked response.
-      }
-    })
-    .handler((req, res) => {
-      const { name } = req.body; // Strictly-typed request.
-      res.status(201).json(`New TODO created: ${name}`); // Type-checked response.
-    })
-});
-```
-
-After running `next-rest-framework generate`, all of above type-safe endpoints will be auto-generated to your OpenAPI spec and exposed in the documentation:
-
-![Next REST Framework docs](@site/static/img/docs-screenshot.jpg)
-
-#### [RPC endpoints](#rpc-endpoints)
-
-##### [App router RPC route](#app-router-rpc-route):
-
-A recommended way is to write your RPC operation in a separate server-side module where they can be consumed both by the RPC endpoints and directly as server-side functions (server actions):
-
-```typescript
-// src/app/actions.ts
-
-'use server';
-
-import { rpcOperation } from 'next-rest-framework';
-import { z } from 'zod';
-
-const TODOS = [
-  {
-    id: 1,
-    name: 'TODO 1',
-    completed: false
-  }
+  // ...
 ];
 
 const todoSchema = z.object({
@@ -271,104 +187,293 @@ const todoSchema = z.object({
   completed: z.boolean()
 });
 
-export const getTodos = rpcOperation({
-  tags: ['RPC']
-})
+export default apiRoute({
+  getTodos: apiRouteOperation({
+    method: 'GET'
+  })
+    .outputs([
+      {
+        status: 200,
+        contentType: 'application/json',
+        body: z.array(todoSchema)
+      }
+    ])
+    .handler((_req, res) => {
+      res.status(200).json(MOCK_TODOS);
+    }),
+
+  createTodo: apiRouteOperation({
+    method: 'POST'
+  })
+    .input({
+      contentType: 'application/json',
+      body: z.object({
+        name: z.string()
+      })
+    })
+    .outputs([
+      {
+        status: 201,
+        contentType: 'application/json',
+        body: z.string()
+      },
+      {
+        status: 401,
+        contentType: 'application/json',
+        body: z.string()
+      }
+    ])
+    // Optional middleware logic executed before request validation.
+    .middleware((req, res) => {
+      if (!req.headers['very-secure']) {
+        res.status(401).json('Unauthorized');
+      }
+    })
+    .handler((req, res) => {
+      const { name } = req.body;
+      // Create a new TODO.
+      res.status(201).json(`New TODO created: ${name}`);
+    })
+});
+```
+
+After running `next-rest-framework generate`, all of above type-safe endpoints will be auto-generated to your OpenAPI spec and exposed in the documentation:
+
+![Next REST Framework docs](@site/static/img/docs-screenshot.jpg)
+
+#### [Form endpoints](#form-endpoints)
+
+##### [App router form route](#app-router-form-route):
+
+When specifying request input schema for validation, the content type header determines what kind of schema you can use to validate the request body.
+When using `application/json`, a plain Zod object schema can be used for the validation. When using `application/x-www-form-urlencoded` or `multipart/form-data` content types, a [zod-form-data](https://www.npmjs.com/package/zod-form-data) schema must be used:
+
+```typescript
+// src/app/api/v2/form-data/url-encoded/route.ts
+
+import { TypedNextResponse, route, routeOperation } from 'next-rest-framework';
+import { zfd } from 'zod-form-data';
+
+// export const runtime = 'edge'; // Edge runtime is supported.
+
+const formSchema = zfd.formData({
+  text: zfd.text()
+});
+
+export const { POST } = route({
+  urlEncodedFormData: routeOperation({
+    method: 'POST'
+  })
+    .input({
+      contentType: 'application/x-www-form-urlencoded',
+      body: formSchema // A zod-form-data schema is required.
+    })
+    .outputs([
+      {
+        status: 200,
+        contentType: 'application/octet-stream',
+        body: formSchema
+      }
+    ])
+    .handler(async (req) => {
+      const { text } = await req.json();
+      // const formData = await req.formData(); // Form can also be parsed as form data.
+
+      // Type-checked response.
+      return TypedNextResponse.json({
+        text
+      });
+    })
+});
+```
+
+For `multipart/form-data` app router example, see [this example](https://github.com/blomqma/next-rest-framework/tree/main/apps/example/src/app/api/v2/form-data/multipart/route.ts).
+
+##### [Pages router form API route](#pages-router-form-api-route):
+
+A form API route with pages router works similarly as the [App router form route](#app-router-form-route) using a `zod-form-data` schema:
+
+```typescript
+// src/pages/api/v1/form-data/url-encoded/index.ts
+
+import { apiRoute, apiRouteOperation } from 'next-rest-framework';
+import { zfd } from 'zod-form-data';
+
+const formSchema = zfd.formData({
+  text: zfd.text()
+});
+
+export default apiRoute({
+  urlEncodedFormData: apiRouteOperation({
+    method: 'POST'
+  })
+    .input({
+      contentType: 'application/x-www-form-urlencoded',
+      body: formSchema // A zod-form-data schema is required.
+    })
+    .outputs([
+      {
+        status: 200,
+        contentType: 'application/json',
+        body: formSchema
+      }
+    ])
+    .handler((req, res) => {
+      const formData = req.body;
+
+      res.json({
+        text: formData.get('text')
+      });
+    })
+});
+```
+
+For `multipart/form-data` pages router example, see [this example](https://github.com/blomqma/next-rest-framework/tree/main/apps/example/pages/api/v1/form-data/multipart/index.ts/form-data/multipart/index.ts).
+
+The form routes will also be included in your OpenAPI spec after running `next-rest-framework generate`.
+
+#### [RPC endpoints](#rpc-endpoints)
+
+Next REST Framework also supports writing RPC-styled APIs that support JSON and form data. A recommended way is to write your RPC operations in a separate server-side module where they can be consumed both by the RPC endpoints and directly as server-side functions (server actions):
+
+```typescript
+// src/app/actions.ts
+
+'use server';
+
+import { rpcOperation } from 'next-rest-framework';
+import { z } from 'zod';
+import { zfd } from 'zod-form-data';
+
+// The RPC operations can be used as server-actions and imported in the RPC route handlers.
+
+const MOCK_TODOS = [
+  {
+    id: 1,
+    name: 'TODO 1',
+    completed: false
+  }
+  // ...
+];
+
+const todoSchema = z.object({
+  id: z.number(),
+  name: z.string(),
+  completed: z.boolean()
+});
+
+export const getTodos = rpcOperation()
   .outputs([
     {
-      schema: z.array(todoSchema)
+      body: z.array(todoSchema)
     }
   ])
   .handler(() => {
-    return TODOS; // Type-checked output.
+    return MOCK_TODOS;
   });
 
-export const getTodoById = rpcOperation({
-  tags: ['RPC']
-})
-  .input(z.string())
+export const getTodoById = rpcOperation()
+  .input({
+    contentType: 'application/json',
+    body: z.string()
+  })
   .outputs([
     {
-      schema: z.object({
+      body: z.object({
         error: z.string()
       })
     },
     {
-      schema: todoSchema
+      body: todoSchema
     }
   ])
   .handler((id) => {
-    const todo = TODOS.find((t) => t.id === Number(id));
+    const todo = MOCK_TODOS.find((t) => t.id === Number(id));
 
     if (!todo) {
-      return { error: 'TODO not found.' }; // Type-checked output.
+      return { error: 'TODO not found.' };
     }
 
-    return todo; // Type-checked output.
+    return todo;
   });
 
-export const createTodo = rpcOperation({
-  tags: ['RPC']
-})
-  .input(
-    z.object({
+export const createTodo = rpcOperation()
+  .input({
+    contentType: 'application/json',
+    body: z.object({
       name: z.string()
     })
-  )
-  .outputs([{ schema: todoSchema }])
-  .handler(
-    async ({
-      name // Strictly-typed input.
-    }) => {
-      // Create todo.
-      const todo = { id: 2, name, completed: false };
-      return todo; // Type-checked output.
-    }
-  );
+  })
+  .outputs([{ body: todoSchema }])
+  .handler(async ({ name }) => {
+    const todo = { id: 4, name, completed: false };
+    return todo;
+  });
 
-export const deleteTodo = rpcOperation({
-  tags: ['RPC']
-})
-  .input(z.string())
+export const deleteTodo = rpcOperation()
+  .input({
+    contentType: 'application/json',
+    body: z.string()
+  })
   .outputs([
-    { schema: z.object({ error: z.string() }) },
-    { schema: z.object({ message: z.string() }) }
+    { body: z.object({ error: z.string() }) },
+    { body: z.object({ message: z.string() }) }
   ])
   .handler((id) => {
-    // Delete todo.
-    const todo = TODOS.find((t) => t.id === Number(id));
+    const todo = MOCK_TODOS.find((t) => t.id === Number(id));
 
     if (!todo) {
       return {
-        error: 'TODO not found.' // Type-checked output.
+        error: 'TODO not found.'
       };
     }
 
-    return { message: 'TODO deleted.' }; // Type-checked output.
+    return { message: 'TODO deleted.' };
+  });
+
+const formSchema = zfd.formData({
+  text: zfd.text()
+});
+
+export const formDataUrlEncoded = rpcOperation()
+  .input({
+    contentType: 'application/x-www-form-urlencoded',
+    body: formSchema // A zod-form-data schema is required.
+  })
+  .outputs([{ body: formSchema }])
+  .handler((formData) => {
+    return {
+      text: formData.get('text')
+    };
+  });
+
+const multipartFormSchema = zfd.formData({
+  text: zfd.text(),
+  file: zfd.file()
+});
+
+export const formDataMultipart = rpcOperation()
+  .input({
+    contentType: 'multipart/form-data',
+    body: multipartFormSchema // A zod-form-data schema is required.
+  })
+  .outputs([
+    {
+      body: z.custom<File>(),
+      // The binary file cannot described with a Zod schema so we define it by hand for the OpenAPI spec.
+      bodySchema: {
+        type: 'string',
+        format: 'binary'
+      }
+    }
+  ])
+  .handler((formData) => {
+    const file = formData.get('file');
+    return file;
   });
 ```
 
-The file path to and RPC route must end with `/[operationId]/route.ts`. Import the RPC operations in to your RPC route handler:
-
-```typescript
-// src/app/api/rpc/[operationId]/route.ts
-
-import { createTodo, deleteTodo, getTodoById, getTodos } from 'src/app/actions';
-import { rpcRoute } from 'next-rest-framework';
-
-// export const runtime = 'edge'; // Edge runtime is supported.
-
-export const { POST } = rpcRoute({
-  getTodos,
-  getTodoById,
-  createTodo,
-  deleteTodo
-});
-
-export type RpcClient = typeof POST.client;
-```
-
-Consume the RPC operations directly in your server-side components:
+Now you can consume the RPC operations directly in your server-side components:
 
 ```typescript
 'use server';
@@ -387,7 +492,39 @@ export default async function Page() {
 }
 ```
 
-##### [Pages router RPC route](#pages-router-rpc-api-route):
+##### [App router RPC route](#app-router-rpc-route):
+
+The file path to an RPC route must end with `/[operationId]/route.ts`. Simply import the RPC operations in to your RPC route handler:
+
+```typescript
+// src/app/api/rpc/[operationId]/route.ts
+
+import {
+  createTodo,
+  deleteTodo,
+  getTodoById,
+  getTodos,
+  formDataUrlEncoded,
+  formDataMultipart
+} from 'src/app/actions';
+import { rpcRoute } from 'next-rest-framework';
+
+// export const runtime = 'edge'; // Edge runtime is supported.
+
+export const { POST } = rpcRoute({
+  getTodos,
+  getTodoById,
+  createTodo,
+  deleteTodo,
+  formDataUrlEncoded,
+  formDataMultipart
+  // You can also inline the RPC operations in this object if you don't need to use server actions.
+});
+
+export type RpcClient = typeof POST.client;
+```
+
+##### [Pages router RPC API route](#pages-router-rpc-api-route):
 
 The filename of an RPC API route must be `[operationId].ts`.
 
@@ -395,11 +532,11 @@ The filename of an RPC API route must be `[operationId].ts`.
 // src/pages/api/rpc/[operationId].ts
 
 import { rpcApiRoute } from 'next-rest-framework';
+// import { ... } from 'src/app/actions';
 
-// Example pages router RPC handler.
 const handler = rpcApiRoute({
   // ...
-  // Exactly the same as the app router example. You can also inline the RPC operations in this object.
+  // Exactly the same as the app router example above.
 });
 
 export default handler;
@@ -413,11 +550,11 @@ The RPC routes will also be included in your OpenAPI spec after running `next-re
 
 #### [REST client](#rest-client)
 
-To achieve end-to-end type-safety, you can use any client implementation that relies on the generated OpenAPI specification, e.g. [openapi-client-axios](https://github.com/openapistack/openapi-client-axios).
+To achieve end-to-end type-safety with your REST endpoints, you can use any client implementation that relies on the generated OpenAPI specification, e.g. [openapi-client-axios](https://github.com/openapistack/openapi-client-axios).
 
 #### [RPC client](#rpc-client)
 
-For client-rendered components you can use the strongly-typed `rpcClient`:
+While you can consume your RPC operations directly as server actions in your React server components, for client-rendered components you can use the strongly-typed `rpcClient`, passing in the exported type from your RPC endpoint as a generic parameter:
 
 ```typescript
 'use client';

--- a/docs/docs/intro.md
+++ b/docs/docs/intro.md
@@ -25,11 +25,14 @@ Next REST Framework is an open-source, opinionated, lightweight, easy-to-use set
 
 ## [Requirements](#requirements)
 
-In order to use Next REST Framework you need to have a Next.js project with the following dependencies installed:
+- Node.js v18.x. If you have an API using `File` or `FormData` web APIs, you might need Node v20.x, see: https://github.com/vercel/next.js/discussions/56032
+
+You also need the following dependencies installed in you Next.js project:
 
 - [Next.js](https://github.com/vercel/next.js) >= v12
 - [Zod](https://github.com/colinhacks/zod) >= v3
 - [TypeScript](https://www.typescriptlang.org/) >= v3
+- Optional, needed if working with forms: [zod-form-data](https://www.npmjs.com/package/zod-form-data) >= v2
 
 ### [Installation](#installation)
 

--- a/packages/next-rest-framework/README.md
+++ b/packages/next-rest-framework/README.md
@@ -37,9 +37,12 @@
     - [REST endpoints](#rest-endpoints)
       - [App router route:](#app-router-route)
       - [Pages router API route:](#pages-router-api-route)
+    - [Form endpoints](#form-endpoints)
+      - [App router form route:](#app-router-form-route)
+      - [Pages router form API route:](#pages-router-form-api-route)
     - [RPC endpoints](#rpc-endpoints)
       - [App router RPC route:](#app-router-rpc-route)
-      - [Pages router RPC route:](#pages-router-rpc-route)
+      - [Pages router RPC API route:](#pages-router-rpc-api-route)
   - [Client](#client)
     - [REST client](#rest-client)
     - [RPC client](#rpc-client)
@@ -93,11 +96,14 @@ This is a monorepo containing the following packages / projects:
 
 ## Requirements
 
-In order to use Next REST Framework you need to have a Next.js project with the following dependencies installed:
+- Node.js v18.x. If you have an API using `File` or `FormData` web APIs, you might need Node v20.x, see: https://github.com/vercel/next.js/discussions/56032
+
+You also need the following dependencies installed in you Next.js project:
 
 - [Next.js](https://github.com/vercel/next.js) >= v12
 - [Zod](https://github.com/colinhacks/zod) >= v3
 - [TypeScript](https://www.typescriptlang.org/) >= v3
+- Optional, needed if working with forms: [zod-form-data](https://www.npmjs.com/package/zod-form-data) >= v2
 
 ## [Installation](#installation)
 
@@ -114,26 +120,48 @@ To get access to the auto-generated documentation, initialize the docs endpoint 
 #### [App router docs route](#app-router-docs-route):
 
 ```typescript
-// src/app/api/route.ts
+// src/app/api/v2/route.ts
 
 import { docsRoute } from 'next-rest-framework';
 
 // export const runtime = 'edge'; // Edge runtime is supported.
 
-export const { GET } = docsRoute();
+export const { GET } = docsRoute({
+  // deniedPaths: [...] // Ignore endpoints from the generated OpenAPI spec.
+  // allowedPaths: [...], // Explicitly set which endpoints to include in the generated OpenAPI spec.
+  // Override and customize the generated OpenAPI spec.
+  openApiObject: {
+    info: {
+      title: 'My API',
+      version: '1.0.0',
+      description: 'My API description.'
+    }
+    // ...
+  },
+  // openApiJsonPath: '/openapi.json', // Customize the path where the OpenAPI spec will be generated.
+  // Customize the rendered documentation.
+  docsConfig: {
+    provider: 'redoc', // redoc | swagger-ui
+    title: 'My API',
+    description: 'My API description.'
+    // ...
+  }
+});
 ```
 
 #### [Pages router docs API route](#pages-router-docs-api-route):
 
 ```typescript
-// src/pages/api.ts
+// src/pages/api/v1/index.ts
 
 import { docsApiRoute } from 'next-rest-framework';
 
-export default docsApiRoute();
+export default docsApiRoute({
+  // See configuration options from above.
+});
 ```
 
-This is enough to get you started. Now you can access the API documentation in your browser. Running `npx next-rest-framework generate` in the project root will generate the `openapi.json` OpenAPI specification file, located in the `public` folder. You can create multiple docs endpoints if needed and specify which config to use for the [CLI](#cli). See the full configuration options of this endpoint in the [Docs handler options](#docs-handler-options) section.
+This is enough to get you started. Now you can access the API documentation in your browser. Running `npx next-rest-framework generate` in the project root will generate the `openapi.json` OpenAPI specification file, located in the `public` folder by default. You can create multiple docs endpoints if needed and specify which config to use for the [CLI](#cli). See the full configuration options of this endpoint in the [Docs handler options](#docs-handler-options) section.
 
 ### [Create endpoint](#create-endpoint)
 
@@ -142,93 +170,77 @@ This is enough to get you started. Now you can access the API documentation in y
 ##### [App router route](#app-router-route):
 
 ```typescript
-// src/app/api/todos/route.ts
+// src/app/api/v2/todos/route.ts
 
 import { TypedNextResponse, route, routeOperation } from 'next-rest-framework';
 import { z } from 'zod';
 
-const TODOS = [
+// export const runtime = 'edge'; // Edge runtime is supported.
+
+const MOCK_TODOS = [
   {
     id: 1,
     name: 'TODO 1',
     completed: false
   }
+  // ...
 ];
 
-// export const runtime = 'edge'; // Edge runtime is supported.
+const todoSchema = z.object({
+  id: z.number(),
+  name: z.string(),
+  completed: z.boolean()
+});
 
-// Example app router route handler with GET/POST handlers.
 export const { GET, POST } = route({
   getTodos: routeOperation({
-    method: 'GET',
-    // Optional OpenAPI operation documentation.
-    openApiOperation: {
-      tags: ['example-api', 'todos', 'app-router']
-    }
+    method: 'GET'
   })
-    // Output schema for strictly-typed responses and OpenAPI documentation.
     .outputs([
       {
         status: 200,
         contentType: 'application/json',
-        schema: z.array(
-          z.object({
-            id: z.number(),
-            name: z.string(),
-            completed: z.boolean()
-          })
-        )
+        body: z.array(todoSchema)
       }
     ])
     .handler(() => {
-      // Type-checked response.
-      return TypedNextResponse.json(TODOS, {
+      return TypedNextResponse.json(MOCK_TODOS, {
         status: 200
       });
     }),
 
   createTodo: routeOperation({
-    method: 'POST',
-    // Optional OpenAPI operation documentation.
-    openApiOperation: {
-      tags: ['example-api', 'todos', 'app-router']
-    }
+    method: 'POST'
   })
-    // Input schema for strictly-typed request, request validation and OpenAPI documentation.
     .input({
       contentType: 'application/json',
       body: z.object({
         name: z.string()
       })
     })
-    // Output schema for strictly-typed responses and OpenAPI documentation.
     .outputs([
       {
         status: 201,
         contentType: 'application/json',
-        schema: z.string()
+        body: z.string()
       },
       {
         status: 401,
         contentType: 'application/json',
-        schema: z.string()
+        body: z.string()
       }
     ])
-    .middleware(
-      // Optional middleware logic executed before request validation.
-      (req) => {
-        if (!req.headers.get('authorization')) {
-          // Type-checked response.
-          return TypedNextResponse.json('Unauthorized', {
-            status: 401
-          });
-        }
+    // Optional middleware logic executed before request validation.
+    .middleware((req) => {
+      if (!req.headers.get('very-secure')) {
+        return TypedNextResponse.json('Unauthorized', {
+          status: 401
+        });
       }
-    )
+    })
     .handler(async (req) => {
-      const { name } = await req.json(); // Strictly-typed request.
+      const { name } = await req.json();
 
-      // Type-checked response.
       return TypedNextResponse.json(`New TODO created: ${name}`, {
         status: 201
       });
@@ -236,7 +248,7 @@ export const { GET, POST } = route({
 });
 ```
 
-The `TypedNextResponse` ensures that the response status codes and content-type headers are type-checked. You can still use the regular `NextResponse` if you prefer to have less type-safety.
+The `TypedNextResponse` ensures that the response status codes and content-type headers are type-checked against the defined outputs. You can still use the regular `NextResponse` if you prefer to have less type-safety.
 
 When using the default `nodejs` runtime with app router routes (`docsRoute` or `route`), you may encounter the [Dynamic server usage](https://nextjs.org/docs/messages/dynamic-server-error) Next.js error when running `next build`. In that case you should force the route to be dynamically rendered with the [dynamic](https://nextjs.org/docs/app/api-reference/file-conventions/route-segment-config#dynamic) option:
 
@@ -247,111 +259,18 @@ export const dynamic = 'force-dynamic';
 ##### [Pages router API route](#pages-router-api-route):
 
 ```typescript
-// src/pages/api/todos.ts
+// src/pages/api/v1/todos/index.ts
 
 import { apiRoute, apiRouteOperation } from 'next-rest-framework';
 import { z } from 'zod';
 
-const TODOS = [
+const MOCK_TODOS = [
   {
     id: 1,
     name: 'TODO 1',
     completed: false
   }
-];
-
-// Example pages router API route with GET/POST handlers.
-export default apiRoute({
-  getTodos: apiRouteOperation({
-    method: 'GET',
-    // Optional OpenAPI operation documentation.
-    openApiOperation: {
-      tags: ['example-api', 'todos', 'pages-router']
-    }
-  })
-    // Output schema for strictly-typed responses and OpenAPI documentation.
-    .outputs([
-      {
-        status: 200,
-        contentType: 'application/json',
-        schema: z.array(
-          z.object({
-            id: z.number(),
-            name: z.string(),
-            completed: z.boolean()
-          })
-        )
-      }
-    ])
-    .handler((_req, res) => {
-      // Type-checked response.
-      res.status(200).json(TODOS);
-    }),
-
-  createTodo: apiRouteOperation({
-    method: 'POST',
-    // Optional OpenAPI operation documentation.
-    openApiOperation: {
-      tags: ['example-api', 'todos', 'pages-router']
-    }
-  })
-    // Input schema for strictly-typed request, request validation and OpenAPI documentation.
-    .input({
-      contentType: 'application/json',
-      body: z.object({
-        name: z.string()
-      })
-    })
-    // Output schema for strictly-typed responses and OpenAPI documentation.
-    .outputs([
-      {
-        status: 201,
-        contentType: 'application/json',
-        schema: z.string()
-      },
-      {
-        status: 401,
-        contentType: 'application/json',
-        schema: z.string()
-      }
-    ])
-    // Optional middleware logic executed before request validation.
-    .middleware((req, res) => {
-      if (!req.headers.authorization) {
-        res.status(401).json('Unauthorized'); // Type-checked response.
-      }
-    })
-    .handler((req, res) => {
-      const { name } = req.body; // Strictly-typed request.
-      res.status(201).json(`New TODO created: ${name}`); // Type-checked response.
-    })
-});
-```
-
-After running `next-rest-framework generate`, all of above type-safe endpoints will be auto-generated to your OpenAPI spec and exposed in the documentation:
-
-![Next REST Framework docs](./docs/static/img/docs-screenshot.jpg)
-
-#### [RPC endpoints](#rpc-endpoints)
-
-##### [App router RPC route](#app-router-rpc-route):
-
-A recommended way is to write your RPC operation in a separate server-side module where they can be consumed both by the RPC endpoints and directly as server-side functions (server actions):
-
-```typescript
-// src/app/actions.ts
-
-'use server';
-
-import { rpcOperation } from 'next-rest-framework';
-import { z } from 'zod';
-
-const TODOS = [
-  {
-    id: 1,
-    name: 'TODO 1',
-    completed: false
-  }
+  // ...
 ];
 
 const todoSchema = z.object({
@@ -360,104 +279,293 @@ const todoSchema = z.object({
   completed: z.boolean()
 });
 
-export const getTodos = rpcOperation({
-  tags: ['RPC']
-})
+export default apiRoute({
+  getTodos: apiRouteOperation({
+    method: 'GET'
+  })
+    .outputs([
+      {
+        status: 200,
+        contentType: 'application/json',
+        body: z.array(todoSchema)
+      }
+    ])
+    .handler((_req, res) => {
+      res.status(200).json(MOCK_TODOS);
+    }),
+
+  createTodo: apiRouteOperation({
+    method: 'POST'
+  })
+    .input({
+      contentType: 'application/json',
+      body: z.object({
+        name: z.string()
+      })
+    })
+    .outputs([
+      {
+        status: 201,
+        contentType: 'application/json',
+        body: z.string()
+      },
+      {
+        status: 401,
+        contentType: 'application/json',
+        body: z.string()
+      }
+    ])
+    // Optional middleware logic executed before request validation.
+    .middleware((req, res) => {
+      if (!req.headers['very-secure']) {
+        res.status(401).json('Unauthorized');
+      }
+    })
+    .handler((req, res) => {
+      const { name } = req.body;
+      // Create a new TODO.
+      res.status(201).json(`New TODO created: ${name}`);
+    })
+});
+```
+
+After running `next-rest-framework generate`, all of above type-safe endpoints will be auto-generated to your OpenAPI spec and exposed in the documentation:
+
+![Next REST Framework docs](./docs/static/img/docs-screenshot.jpg)
+
+#### [Form endpoints](#form-endpoints)
+
+##### [App router form route](#app-router-form-route):
+
+When specifying request input schema for validation, the content type header determines what kind of schema you can use to validate the request body.
+When using `application/json`, a plain Zod object schema can be used for the validation. When using `application/x-www-form-urlencoded` or `multipart/form-data` content types, a [zod-form-data](https://www.npmjs.com/package/zod-form-data) schema must be used:
+
+```typescript
+// src/app/api/v2/form-data/url-encoded/route.ts
+
+import { TypedNextResponse, route, routeOperation } from 'next-rest-framework';
+import { zfd } from 'zod-form-data';
+
+// export const runtime = 'edge'; // Edge runtime is supported.
+
+const formSchema = zfd.formData({
+  text: zfd.text()
+});
+
+export const { POST } = route({
+  urlEncodedFormData: routeOperation({
+    method: 'POST'
+  })
+    .input({
+      contentType: 'application/x-www-form-urlencoded',
+      body: formSchema // A zod-form-data schema is required.
+    })
+    .outputs([
+      {
+        status: 200,
+        contentType: 'application/octet-stream',
+        body: formSchema
+      }
+    ])
+    .handler(async (req) => {
+      const { text } = await req.json();
+      // const formData = await req.formData(); // Form can also be parsed as form data.
+
+      // Type-checked response.
+      return TypedNextResponse.json({
+        text
+      });
+    })
+});
+```
+
+For `multipart/form-data` app router example, see [this example](https://github.com/blomqma/next-rest-framework/tree/main/apps/example/src/app/api/v2/form-data/multipart/route.ts).
+
+##### [Pages router form API route](#pages-router-form-api-route):
+
+A form API route with pages router works similarly as the [App router form route](#app-router-form-route) using a `zod-form-data` schema:
+
+```typescript
+// src/pages/api/v1/form-data/url-encoded/index.ts
+
+import { apiRoute, apiRouteOperation } from 'next-rest-framework';
+import { zfd } from 'zod-form-data';
+
+const formSchema = zfd.formData({
+  text: zfd.text()
+});
+
+export default apiRoute({
+  urlEncodedFormData: apiRouteOperation({
+    method: 'POST'
+  })
+    .input({
+      contentType: 'application/x-www-form-urlencoded',
+      body: formSchema // A zod-form-data schema is required.
+    })
+    .outputs([
+      {
+        status: 200,
+        contentType: 'application/json',
+        body: formSchema
+      }
+    ])
+    .handler((req, res) => {
+      const formData = req.body;
+
+      res.json({
+        text: formData.get('text')
+      });
+    })
+});
+```
+
+For `multipart/form-data` pages router example, see [this example](https://github.com/blomqma/next-rest-framework/tree/main/apps/example/pages/api/v1/form-data/multipart/index.ts/form-data/multipart/index.ts).
+
+The form routes will also be included in your OpenAPI spec after running `next-rest-framework generate`.
+
+#### [RPC endpoints](#rpc-endpoints)
+
+Next REST Framework also supports writing RPC-styled APIs that support JSON and form data. A recommended way is to write your RPC operations in a separate server-side module where they can be consumed both by the RPC endpoints and directly as server-side functions (server actions):
+
+```typescript
+// src/app/actions.ts
+
+'use server';
+
+import { rpcOperation } from 'next-rest-framework';
+import { z } from 'zod';
+import { zfd } from 'zod-form-data';
+
+// The RPC operations can be used as server-actions and imported in the RPC route handlers.
+
+const MOCK_TODOS = [
+  {
+    id: 1,
+    name: 'TODO 1',
+    completed: false
+  }
+  // ...
+];
+
+const todoSchema = z.object({
+  id: z.number(),
+  name: z.string(),
+  completed: z.boolean()
+});
+
+export const getTodos = rpcOperation()
   .outputs([
     {
-      schema: z.array(todoSchema)
+      body: z.array(todoSchema)
     }
   ])
   .handler(() => {
-    return TODOS; // Type-checked output.
+    return MOCK_TODOS;
   });
 
-export const getTodoById = rpcOperation({
-  tags: ['RPC']
-})
-  .input(z.string())
+export const getTodoById = rpcOperation()
+  .input({
+    contentType: 'application/json',
+    body: z.string()
+  })
   .outputs([
     {
-      schema: z.object({
+      body: z.object({
         error: z.string()
       })
     },
     {
-      schema: todoSchema
+      body: todoSchema
     }
   ])
   .handler((id) => {
-    const todo = TODOS.find((t) => t.id === Number(id));
+    const todo = MOCK_TODOS.find((t) => t.id === Number(id));
 
     if (!todo) {
-      return { error: 'TODO not found.' }; // Type-checked output.
+      return { error: 'TODO not found.' };
     }
 
-    return todo; // Type-checked output.
+    return todo;
   });
 
-export const createTodo = rpcOperation({
-  tags: ['RPC']
-})
-  .input(
-    z.object({
+export const createTodo = rpcOperation()
+  .input({
+    contentType: 'application/json',
+    body: z.object({
       name: z.string()
     })
-  )
-  .outputs([{ schema: todoSchema }])
-  .handler(
-    async ({
-      name // Strictly-typed input.
-    }) => {
-      // Create todo.
-      const todo = { id: 2, name, completed: false };
-      return todo; // Type-checked output.
-    }
-  );
+  })
+  .outputs([{ body: todoSchema }])
+  .handler(async ({ name }) => {
+    const todo = { id: 4, name, completed: false };
+    return todo;
+  });
 
-export const deleteTodo = rpcOperation({
-  tags: ['RPC']
-})
-  .input(z.string())
+export const deleteTodo = rpcOperation()
+  .input({
+    contentType: 'application/json',
+    body: z.string()
+  })
   .outputs([
-    { schema: z.object({ error: z.string() }) },
-    { schema: z.object({ message: z.string() }) }
+    { body: z.object({ error: z.string() }) },
+    { body: z.object({ message: z.string() }) }
   ])
   .handler((id) => {
-    // Delete todo.
-    const todo = TODOS.find((t) => t.id === Number(id));
+    const todo = MOCK_TODOS.find((t) => t.id === Number(id));
 
     if (!todo) {
       return {
-        error: 'TODO not found.' // Type-checked output.
+        error: 'TODO not found.'
       };
     }
 
-    return { message: 'TODO deleted.' }; // Type-checked output.
+    return { message: 'TODO deleted.' };
+  });
+
+const formSchema = zfd.formData({
+  text: zfd.text()
+});
+
+export const formDataUrlEncoded = rpcOperation()
+  .input({
+    contentType: 'application/x-www-form-urlencoded',
+    body: formSchema // A zod-form-data schema is required.
+  })
+  .outputs([{ body: formSchema }])
+  .handler((formData) => {
+    return {
+      text: formData.get('text')
+    };
+  });
+
+const multipartFormSchema = zfd.formData({
+  text: zfd.text(),
+  file: zfd.file()
+});
+
+export const formDataMultipart = rpcOperation()
+  .input({
+    contentType: 'multipart/form-data',
+    body: multipartFormSchema // A zod-form-data schema is required.
+  })
+  .outputs([
+    {
+      body: z.custom<File>(),
+      // The binary file cannot described with a Zod schema so we define it by hand for the OpenAPI spec.
+      bodySchema: {
+        type: 'string',
+        format: 'binary'
+      }
+    }
+  ])
+  .handler((formData) => {
+    const file = formData.get('file');
+    return file;
   });
 ```
 
-The file path to and RPC route must end with `/[operationId]/route.ts`. Import the RPC operations in to your RPC route handler:
-
-```typescript
-// src/app/api/rpc/[operationId]/route.ts
-
-import { createTodo, deleteTodo, getTodoById, getTodos } from 'src/app/actions';
-import { rpcRoute } from 'next-rest-framework';
-
-// export const runtime = 'edge'; // Edge runtime is supported.
-
-export const { POST } = rpcRoute({
-  getTodos,
-  getTodoById,
-  createTodo,
-  deleteTodo
-});
-
-export type RpcClient = typeof POST.client;
-```
-
-Consume the RPC operations directly in your server-side components:
+Now you can consume the RPC operations directly in your server-side components:
 
 ```typescript
 'use server';
@@ -476,7 +584,39 @@ export default async function Page() {
 }
 ```
 
-##### [Pages router RPC route](#pages-router-rpc-api-route):
+##### [App router RPC route](#app-router-rpc-route):
+
+The file path to an RPC route must end with `/[operationId]/route.ts`. Simply import the RPC operations in to your RPC route handler:
+
+```typescript
+// src/app/api/rpc/[operationId]/route.ts
+
+import {
+  createTodo,
+  deleteTodo,
+  getTodoById,
+  getTodos,
+  formDataUrlEncoded,
+  formDataMultipart
+} from 'src/app/actions';
+import { rpcRoute } from 'next-rest-framework';
+
+// export const runtime = 'edge'; // Edge runtime is supported.
+
+export const { POST } = rpcRoute({
+  getTodos,
+  getTodoById,
+  createTodo,
+  deleteTodo,
+  formDataUrlEncoded,
+  formDataMultipart
+  // You can also inline the RPC operations in this object if you don't need to use server actions.
+});
+
+export type RpcClient = typeof POST.client;
+```
+
+##### [Pages router RPC API route](#pages-router-rpc-api-route):
 
 The filename of an RPC API route must be `[operationId].ts`.
 
@@ -484,11 +624,11 @@ The filename of an RPC API route must be `[operationId].ts`.
 // src/pages/api/rpc/[operationId].ts
 
 import { rpcApiRoute } from 'next-rest-framework';
+// import { ... } from 'src/app/actions';
 
-// Example pages router RPC handler.
 const handler = rpcApiRoute({
   // ...
-  // Exactly the same as the app router example. You can also inline the RPC operations in this object.
+  // Exactly the same as the app router example above.
 });
 
 export default handler;
@@ -502,11 +642,11 @@ The RPC routes will also be included in your OpenAPI spec after running `next-re
 
 #### [REST client](#rest-client)
 
-To achieve end-to-end type-safety, you can use any client implementation that relies on the generated OpenAPI specification, e.g. [openapi-client-axios](https://github.com/openapistack/openapi-client-axios).
+To achieve end-to-end type-safety with your REST endpoints, you can use any client implementation that relies on the generated OpenAPI specification, e.g. [openapi-client-axios](https://github.com/openapistack/openapi-client-axios).
 
 #### [RPC client](#rpc-client)
 
-For client-rendered components you can use the strongly-typed `rpcClient`:
+While you can consume your RPC operations directly as server actions in your React server components, for client-rendered components you can use the strongly-typed `rpcClient`, passing in the exported type from your RPC endpoint as a generic parameter:
 
 ```typescript
 'use client';
@@ -572,16 +712,11 @@ The docs config options can be used to customize the generated docs:
 
 #### [Route handler options](#route-handler-options)
 
-The following options can be passed to the `routeHandler` (app router) and `apiRouteHandler` (pages router) functions to create new API endpoints:
-
-| Name                                                       | Description                                                                                                                                                 | Required |
-| ---------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- |
-| `GET \| PUT \| POST \| DELETE \| OPTIONS \| HEAD \| PATCH` | A [Method handler](#method-handlers) object.                                                                                                                | `true`   |
-| `openApiPath`                                              | An OpenAPI [Path Item Object](https://swagger.io/specification/#path-item-object) that can be used to override and extend the auto-generated specification. | `false`  |
+The `routeHandler` (app router) and `apiRouteHandler` (pages router) functions allow you to pass an object as the second parameter, where you can define a property called `openApiPath`. This property is an OpenAPI [Path Item Object](https://swagger.io/specification/#path-item-object) that can be used to override and extend the auto-generated specification for the given route.
 
 #### [Route operations](#route-operations)
 
-The route operation functions `routeOperation` (app router) and `apiRouteOperation` (pages router) allow you to define your API handlers for your endpoints. These functions accept an OpenAPI [Operation object](https://swagger.io/specification/#operation-object) as a parameter, that can be used to override the auto-generated specification. Calling this function allows you to chain your API handler logic with the following functions:
+The route operation functions `routeOperation` (app router) and `apiRouteOperation` (pages router) allow you to define your method handlers for your endpoints. These functions require you to pass an object where you will define the method for the given operation, as well as optionally a property called `openApiOperation`. This property is an OpenAPI [Operation object](https://swagger.io/specification/#operation-object) that can be used to override and extend the auto-generated specification for the given operation. Calling the `routeOperation` and `apiRouteOperation` functions allows you to chain your API handler logic with the following functions:
 
 | Name         | Description                                                                                                                                                                                                                                                          |
 | ------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -594,11 +729,14 @@ The route operation functions `routeOperation` (app router) and `apiRouteOperati
 
 The route operation input function is used for type-checking, validation and documentation of the request, taking in an object with the following properties:
 
-| Name          | Description                                                                                                                                                                                            | Required |
-| ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | -------- |
-| `contentType` | The content type header of the request. When the content type is defined, a request with an incorrect content type header will get an error response.                                                  | `false`  |
-| `body`        | A [Zod](https://github.com/colinhacks/zod) schema describing the format of the request body. When the body schema is defined, a request with an invalid request body will get an error response.       | `false`  |
-| `query`       | A [Zod](https://github.com/colinhacks/zod) schema describing the format of the query parameters. When the query schema is defined, a request with invalid query parameters will get an error response. | `false`  |
+| Name          | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                            | Required |
+| ------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- |
+| `contentType` | The content type header of the request. When the content type is defined, a request with an incorrect content type header will get an error response.                                                                                                                                                                                                                                                                                                                  | `false`  |
+| `body`        | A [Zod](https://github.com/colinhacks/zod) schema describing the format of the request body. When using `application/x-www-form-urlencoded` or `multipart/form-data` content types, this should be a `zod-form-data` schema instead. When the body schema is defined, a request with an invalid request body will get an error response. The request body is parsed using this schema and updated to the request if valid, so the body should always match the schema. | `false`  |
+| `bodySchema`  | A JSON schema that you can provide in case the conversion of the `body` Zod schema fails or produces an incorrect result in your OpenAPI spec.                                                                                                                                                                                                                                                                                                                         | `false`  |
+| `query`       | A [Zod](https://github.com/colinhacks/zod) schema describing the format of the query parameters. When the query schema is defined, a request with invalid query parameters will get an error response. Query parameters are parsed using this schema and updated to the request if valid, so the query parameters from the request should always match the schema.                                                                                                     | `false`  |
+| `querySchema` | A JSON schema that you can provide in case the conversion of the `query` Zod schema fails or produces an incorrect result in your OpenAPI spec.                                                                                                                                                                                                                                                                                                                        | `false`  |
+| `params`      | A [Zod](https://github.com/colinhacks/zod) schema describing the format of the path parameters for strong typing when using them in your route handler.                                                                                                                                                                                                                                                                                                                | `false`  |
 
 Calling the route operation input function allows you to chain your API handler logic with the [Route operation outputs](#route-operation-outputs), [Route operation middleware](#route-operation-middleware) and [Route operation handler](#route-operation-handler) functions.
 
@@ -606,29 +744,31 @@ Calling the route operation input function allows you to chain your API handler 
 
 The route operation outputs function is used for type-checking and documentation of the response, taking in an array of objects with the following properties:
 
-| Name          | Description                                                                                   | Required |
-| ------------- | --------------------------------------------------------------------------------------------- | -------- |
-| `status`      | A status code that your API can return.                                                       | `true`   |
-| `contentType` | The content type header of the response.                                                      | `true`   |
-| `schema`      | A [Zod](https://github.com/colinhacks/zod) schema describing the format of the response data. |  `true`  |
+| Name          | Description                                                                                                                                    | Required |
+| ------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- | -------- |
+| `status`      | A status code that your API can return.                                                                                                        | `true`   |
+| `contentType` | The content type header of the response.                                                                                                       | `true`   |
+| `body`        | A [Zod](https://github.com/colinhacks/zod) (or `zod-form-data`) schema describing the format of the response data.                             |  `true`  |
+| `bodySchema`  | A JSON schema that you can provide in case the conversion of the `body` Zod schema fails or produces an incorrect result in your OpenAPI spec. | `false`  |
+| `name`        | An optional name used in the generated OpenAPI spec for the response body, e.g. `GetTodosSuccessResponse`.                                     | `false`  |
 
 Calling the route operation outputs function allows you to chain your API handler logic with the [Route operation middleware](#route-operation-middleware) and [Route operation handler](#route-operation-handler) functions.
 
 ##### [Route operation middleware](#route-operation-middleware)
 
-The route operation middleware function is executed before validating the request input. The function takes in the same parameters as the Next.js [router handlers](https://nextjs.org/docs/app/building-your-application/routing/route-handlers) and [API routes](https://nextjs.org/docs/pages/building-your-application/routing/api-routes) handlers. Additionally, as a second parameter this function takes the return value of your last middleware function, defaulting to an empty object. Throwing an error inside a middleware function will stop the execution of the handler and you can also return a custom response like you would do within the [Handler](#handler) function. Calling the route operation middleware function allows you to chain your API handler logic with the [Handler](#handler) function. Alternatively, you may chain up to three middleware functions together:
+The route operation middleware function is executed before validating the request input. The function takes in the same parameters as the Next.js [router handler](https://nextjs.org/docs/app/building-your-application/routing/route-handlers) (app router) and [API route](https://nextjs.org/docs/pages/building-your-application/routing/api-routes) (pages router) functions. Additionally, as a second parameter this function takes the return value of your last middleware function, defaulting to an empty object. Throwing an error inside a middleware function will stop the execution of the handler and you can also return a custom response like you would do within the [Route operation handler](#route-operation-handler) function. Calling the route operation middleware function allows you to chain your API handler logic with the [Route operation handler](#route-operation-handler) function. Alternatively, you may chain up to three middleware functions together:
 
 ```typescript
-// ...
-const handler = route({
-  getTodos: routeOperation()
+// App router.
+export const { GET } = route({
+  getTodos: routeOperation({ method: 'GET' })
     .middleware(() => {
       return { foo: 'bar' };
     })
     .middleware((_req, _ctx, { foo }) => {
-      // if (myCondition) {
-      //   return NextResponse.json({ error: 'My error.' });
-      // }
+      if (myCondition) {
+        return NextResponse.json({ error: 'My error.' }, { status: 400 });
+      }
 
       return {
         foo,
@@ -639,34 +779,43 @@ const handler = route({
       // ...
     })
 });
+
+// Pages router.
+export default apiRoute({
+  getTodos: routeOperation({ method: 'GET' })
+    .middleware(() => {
+      return { foo: 'bar' };
+    })
+    .middleware((req, res, { foo }) => {
+      if (myCondition) {
+        res.status(400).json({ error: 'My error.' });
+        return;
+      }
+
+      return {
+        foo,
+        bar: 'baz'
+      };
+    })
+    .handler((req, res, { foo, bar }) => {
+      // ...
+    })
+});
 ```
 
 ##### [Route operation handler](#route-operation-handler)
 
-The route operation handler function is a strongly-typed function to implement the business logic for your API. The function takes in strongly-typed versions of the same parameters as the Next.js [router handlers](https://nextjs.org/docs/app/building-your-application/routing/route-handlers) and [API routes](https://nextjs.org/docs/pages/building-your-application/routing/api-routes) handlers. Additionally, as a third parameter this function takes the return value of your last middleware function:
-
-```typescript
-// ...
-const handler = route({
-  getTodos: routeOperation()
-    .middleware(() => {
-      return { foo: "bar" };
-    })
-    .handler((_req, _ctx, { foo }) => {
-      // ...
-    });
-});
-```
+The route operation handler function is a strongly-typed function to implement the business logic for your API. The function takes in strongly-typed versions of the same parameters as the Next.js [router handler](https://nextjs.org/docs/app/building-your-application/routing/route-handlers) (app router) and [API route](https://nextjs.org/docs/pages/building-your-application/routing/api-routes) (pages router) functions. Additionally, as a third parameter this function takes the return value of your last middleware function (see above), defaulting to an empty object.
 
 ### RPC
 
 #### [RPC route handler options](#rpc-route-handler-options)
 
-The `rpcRouteHandler` (app router) and `rpcApiRouteHandler` (pages router) functions allow you to define your API handlers for your RPC endpoints. These functions accept an OpenAPI [Operation object](https://swagger.io/specification/#operation-object) as a parameter, that can be used to override the auto-generated specification.
+The `rpcRouteHandler` (app router) and `rpcApiRouteHandler` (pages router) functions allow you to pass an object as the second parameter, where you can define a property called `openApiPath`. This property is an OpenAPI [Path Item Object](https://swagger.io/specification/#path-item-object) that can be used to override and extend the auto-generated specification for the given route.
 
 #### [RPC operations](#rpc-operations)
 
-The `rpcOperation` function allows you to define your API handlers for your RPC endpoint. Calling this function allows you to chain your API handler logic with the following functions.
+The `rpcOperation` function allows you to define your API handlers for your RPC endpoint. This function allows you to pass an OpenAPI [Operation object](https://swagger.io/specification/#operation-object) as a parameter, that can be used to override and extend the auto-generated specification for the given operation. Calling this function allows you to chain your API handler logic with the following functions.
 
 | Name         | Description                                                                                                                                                                                                                                                         |
 | ------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -677,7 +826,13 @@ The `rpcOperation` function allows you to define your API handlers for your RPC 
 
 ##### [RPC operation input](#rpc-operation-input)
 
-The RPC operation input function is used for type-checking, validation and documentation of the RPC call. It takes in a A [Zod](https://github.com/colinhacks/zod) schema as a parameter that describes the format of the operation input. When the input schema is defined, an RPC call with invalid input will get an error response.
+The RPC operation input function is used for type-checking, validation and documentation of the RPC call, taking in an object with the following properties:
+
+| Name          | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                            | Required |
+| ------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- |
+| `contentType` | The content type header of the request, limited to `application/json`, `application/x-www-form-urlencoded` and `multipart/form-data`. When the content type is defined, a request with an incorrect content type header will get an error response.                                                                                                                                                                                                                    | `false`  |
+| `body`        | A [Zod](https://github.com/colinhacks/zod) schema describing the format of the request body. When using `application/x-www-form-urlencoded` or `multipart/form-data` content types, this should be a `zod-form-data` schema instead. When the body schema is defined, a request with an invalid request body will get an error response. The request body is parsed using this schema and updated to the request if valid, so the body should always match the schema. | `false`  |
+| `bodySchema`  | A JSON schema that you can provide in case the conversion of the `body` Zod schema fails or produces an incorrect result in your OpenAPI spec.                                                                                                                                                                                                                                                                                                                         | `false`  |
 
 Calling the RPC input function allows you to chain your API handler logic with the [RPC operation outputs](#rpc-operation-outputs), [RPC middleware](#rpc-operation-middleware) and [RPC handler](#rpc-operation-handler) functions.
 
@@ -685,10 +840,11 @@ Calling the RPC input function allows you to chain your API handler logic with t
 
 The RPC operation outputs function is used for type-checking and documentation of the response, taking in an array of objects with the following properties:
 
-| Name     | Description                                                                                   | Required |
-| -------- | --------------------------------------------------------------------------------------------- | -------- |
-| `schema` | A [Zod](https://github.com/colinhacks/zod) schema describing the format of the response data. |  `true`  |
-| `name`   | An optional name used in the generated OpenAPI spec, e.g. `GetTodosErrorResponse`.            | `false`  |
+| Name         | Description                                                                                                                                    | Required |
+| ------------ | ---------------------------------------------------------------------------------------------------------------------------------------------- | -------- |
+| `body`       | A [Zod](https://github.com/colinhacks/zod) (or `zod-form-data`) schema describing the format of the response data.                             |  `true`  |
+| `bodySchema` | A JSON schema that you can provide in case the conversion of the `body` Zod schema fails or produces an incorrect result in your OpenAPI spec. | `false`  |
+| `name`       | An optional name used in the generated OpenAPI spec for the response body, e.g. `GetTodosSuccessResponse`.                                     | `false`  |
 
 Calling the RPC operation outputs function allows you to chain your API handler logic with the [RPC operation middleware](#rpc-operation-middleware) and [RPC operation handler](#rpc-operation-handler) functions.
 
@@ -697,16 +853,16 @@ Calling the RPC operation outputs function allows you to chain your API handler 
 The RPC operation middleware function is executed before validating RPC operation input. The function takes in strongly typed parameters typed by the [RPC operation input](#rpc-operation-input) function. Additionally, as a second parameter this function takes the return value of your last middleware function, defaulting to an empty object. Throwing an error inside a middleware function will stop the execution of the handler. Calling the RPC operation middleware function allows you to chain your RPC API handler logic with the [RPC operation handler](#rpc-operation-handler) function. Alternatively, you may chain up to three middleware functions together:
 
 ```typescript
-// ...
-const handler = rpcRoute({
+// App router.
+export const { POST } = rpcRoute({
   getTodos: rpcOperation()
     .middleware(() => {
       return { foo: 'bar' };
     })
     .middleware((_input, { foo }) => {
-      // if (myCondition) {
-      //   throw Error('My error.')
-      // }
+      if (myCondition) {
+        throw Error('My error.');
+      }
 
       return {
         foo,
@@ -717,24 +873,16 @@ const handler = rpcRoute({
       // ...
     })
 });
+
+// Pages router.
+export default rpcApiRoute({
+  // ... Same as above.
+});
 ```
 
 ##### [RPC operation handler](#rpc-operation-handler)
 
-The RPC operation handler function is a strongly-typed function to implement the business logic for your API. The function takes in strongly typed parameters typed by the [RPC operation input](#rpc-operation-input) function. Additionally, as a second parameter this function takes the return value of your last middleware function:
-
-```typescript
-// ...
-const handler = rpcApiRoute({
-  getTodos: rpcOperation()
-    .middleware(() => {
-      return { foo: "bar" };
-    })
-    .handler((_input, { foo }) => {
-      // ...
-    });
-});
-```
+The RPC operation handler function is a strongly-typed function to implement the business logic for your API. The function takes in strongly typed parameters typed by the [RPC operation input](#rpc-operation-input) function. Additionally, as a second parameter this function takes the return value of your last middleware function (see above), defaulting to an empty object.
 
 ## [CLI](#cli)
 

--- a/packages/next-rest-framework/package.json
+++ b/packages/next-rest-framework/package.json
@@ -39,24 +39,27 @@
     "chalk": "4.1.2",
     "commander": "10.0.1",
     "esbuild": "0.19.11",
+    "fast-glob": "3.3.2",
+    "formidable": "^3.5.1",
     "lodash": "4.17.21",
     "prettier": "3.0.2",
-    "fast-glob": "3.3.2",
-    "zod-to-json-schema": "3.21.4",
-    "qs": "6.11.2"
+    "qs": "6.11.2",
+    "zod-to-json-schema": "3.21.4"
   },
   "devDependencies": {
+    "@types/formidable": "^3.4.5",
     "@types/jest": "29.5.4",
     "@types/lodash": "4.14.197",
     "@types/qs": "6.9.11",
     "jest": "29.6.4",
+    "next": "*",
     "node-mocks-http": "1.13.0",
     "openapi-types": "12.1.3",
     "ts-jest": "29.1.1",
     "ts-node": "10.9.1",
     "tsup": "8.0.1",
     "typescript": "*",
-    "next": "*",
-    "zod": "*"
+    "zod": "*",
+    "zod-form-data": "*"
   }
 }

--- a/packages/next-rest-framework/src/client/rpc-client.ts
+++ b/packages/next-rest-framework/src/client/rpc-client.ts
@@ -3,7 +3,7 @@ import { type RpcOperationDefinition } from '../shared';
 type RpcRequestInit = Omit<RequestInit, 'method' | 'body'>;
 
 export type RpcClient<
-  T extends Record<string, RpcOperationDefinition<any, any, any>>
+  T extends Record<string, RpcOperationDefinition<any, any, any, any>>
 > = {
   [key in keyof T]: T[key] & { _meta: never };
 };
@@ -41,7 +41,7 @@ const fetcher = async ({
 };
 
 export const rpcClient = <
-  T extends Record<string, RpcOperationDefinition<any, any, any>>
+  T extends Record<string, RpcOperationDefinition<any, any, any, any>>
 >({
   url: _url,
   init

--- a/packages/next-rest-framework/src/constants.ts
+++ b/packages/next-rest-framework/src/constants.ts
@@ -1,3 +1,5 @@
+import { type FormDataContentType } from './types';
+
 export const DEFAULT_ERRORS = {
   unexpectedError: 'An unknown error occurred, trying again might help.',
   methodNotAllowed: 'Method not allowed.',
@@ -39,3 +41,6 @@ export const DEFAULT_FAVICON_URL =
 
 export const DEFAULT_LOGO_URL =
   'https://raw.githubusercontent.com/blomqma/next-rest-framework/d02224b38d07ede85257b22ed50159a947681f99/packages/next-rest-framework/logo.svg';
+
+export const FORM_DATA_CONTENT_TYPES_THAT_SUPPORT_VALIDATION: FormDataContentType[] =
+  ['multipart/form-data', 'application/x-www-form-urlencoded'];

--- a/packages/next-rest-framework/src/shared/form-data.ts
+++ b/packages/next-rest-framework/src/shared/form-data.ts
@@ -1,0 +1,39 @@
+import { type NextApiRequest } from 'next/types';
+import { Formidable } from 'formidable';
+import { readFileSync } from 'fs';
+
+export const parseMultiPartFormData = async (req: NextApiRequest) =>
+  await new Promise<FormData>((resolve, reject) => {
+    const form = new Formidable();
+
+    form.parse(req, (err, fields, files) => {
+      if (err) {
+        reject(err);
+        return;
+      }
+
+      const formData = new FormData();
+
+      Object.entries(fields).forEach(([key, value]) => {
+        if (value?.[0]) {
+          formData.append(key, value[0]);
+        }
+      });
+
+      Object.entries(files).forEach(([key, fileArray]) => {
+        if (fileArray && fileArray.length > 0) {
+          fileArray.forEach((file) => {
+            const fileContent = readFileSync(file.filepath);
+
+            const blob = new Blob([fileContent], {
+              type: file.mimetype ?? ''
+            });
+
+            formData.append(key, blob, file.originalFilename ?? '');
+          });
+        }
+      });
+
+      resolve(formData);
+    });
+  });

--- a/packages/next-rest-framework/tests/utils.ts
+++ b/packages/next-rest-framework/tests/utils.ts
@@ -40,7 +40,10 @@ export const createMockRouteRequest = <Body, Query>({
 } => ({
   req: new NextRequest(`http://localhost:3000${path}?${qs.stringify(query)}`, {
     method,
-    body: JSON.stringify(body),
+    body:
+      body instanceof URLSearchParams || body instanceof FormData
+        ? body
+        : JSON.stringify(body),
     headers: {
       host: 'localhost:3000',
       'x-forwarded-proto': 'http',
@@ -71,7 +74,6 @@ export const createMockRpcRouteRequest = <Body>({
     body,
     method,
     headers: {
-      'Content-Type': 'application/json',
       ...headers
     }
   });
@@ -117,7 +119,6 @@ export const createMockRpcApiRouteRequest = <Body>({
     body,
     method,
     headers: {
-      'Content-Type': 'application/json',
       ...headers
     }
   });
@@ -131,7 +132,11 @@ export const getExpectedSpec = ({
   allowedPaths: string[];
   deniedPaths: string[];
 }) => {
-  const schema = getJsonSchema({ schema: zodSchema });
+  const schema = getJsonSchema({
+    schema: zodSchema,
+    operationId: 'test',
+    type: 'input-body'
+  });
 
   const parameters: OpenAPIV3_1.ParameterObject[] = [
     {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -66,6 +66,9 @@ importers:
       next-rest-framework:
         specifier: workspace:*
         version: link:../../packages/next-rest-framework
+      zod-form-data:
+        specifier: 2.0.2
+        version: 2.0.2(zod@3.22.2)
     devDependencies:
       autoprefixer:
         specifier: 10.0.1
@@ -125,6 +128,9 @@ importers:
       fast-glob:
         specifier: 3.3.2
         version: 3.3.2
+      formidable:
+        specifier: ^3.5.1
+        version: 3.5.1
       lodash:
         specifier: 4.17.21
         version: 4.17.21
@@ -138,6 +144,9 @@ importers:
         specifier: 3.21.4
         version: 3.21.4(zod@3.22.2)
     devDependencies:
+      '@types/formidable':
+        specifier: ^3.4.5
+        version: 3.4.5
       '@types/jest':
         specifier: 29.5.4
         version: 29.5.4
@@ -174,6 +183,9 @@ importers:
       zod:
         specifier: '*'
         version: 3.22.2
+      zod-form-data:
+        specifier: '*'
+        version: 2.0.2(zod@3.22.2)
 
 packages:
 
@@ -3618,6 +3630,12 @@ packages:
       '@types/serve-static': 1.15.2
     dev: false
 
+  /@types/formidable@3.4.5:
+    resolution: {integrity: sha512-s7YPsNVfnsng5L8sKnG/Gbb2tiwwJTY1conOkJzTMRvJAlLFW1nEua+ADsJQu8N1c0oTHx9+d5nqg10WuT9gHQ==}
+    dependencies:
+      '@types/node': 20.5.4
+    dev: true
+
   /@types/graceful-fs@4.1.6:
     resolution: {integrity: sha512-Sig0SNORX9fdW+bQuTEovKj3uHcUL6LQKbCrrqb1X7J6/ReAbhCXRAhc+SMejhLELFj2QcyuxmUooZ4bt5ReSw==}
     dependencies:
@@ -5591,6 +5609,13 @@ packages:
       - supports-color
     dev: false
 
+  /dezalgo@1.0.4:
+    resolution: {integrity: sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==}
+    dependencies:
+      asap: 2.0.6
+      wrappy: 1.0.2
+    dev: false
+
   /didyoumean@1.2.2:
     resolution: {integrity: sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==}
     dev: true
@@ -6635,6 +6660,14 @@ packages:
       webpack: 5.88.2
     dev: false
 
+  /formidable@3.5.1:
+    resolution: {integrity: sha512-WJWKelbRHN41m5dumb0/k8TeAx7Id/y3a+Z7QfhxP/htI9Js5zYaEDtG8uMgG0vM0lOlqnmjE99/kfpOYi/0Og==}
+    dependencies:
+      dezalgo: 1.0.4
+      hexoid: 1.0.0
+      once: 1.4.0
+    dev: false
+
   /forwarded@0.2.0:
     resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
     engines: {node: '>= 0.6'}
@@ -7040,6 +7073,11 @@ packages:
   /he@1.2.0:
     resolution: {integrity: sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==}
     hasBin: true
+    dev: false
+
+  /hexoid@1.0.0:
+    resolution: {integrity: sha512-QFLV0taWQOZtvIRIAdBChesmogZrtuXvVWsFHZTk2SU+anspqZ2vMnoLg7IE1+Uk16N19APic1BuF8bC8c2m5g==}
+    engines: {node: '>=8'}
     dev: false
 
   /history@4.10.1:
@@ -12042,6 +12080,13 @@ packages:
   /yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
+
+  /zod-form-data@2.0.2(zod@3.22.2):
+    resolution: {integrity: sha512-sKTi+k0fvkxdakD0V5rq+9WVJA3cuTQUfEmNqvHrTzPLvjfLmkkBLfR0ed3qOi9MScJXTHIDH/jUNnEJ3CBX4g==}
+    peerDependencies:
+      zod: '>= 3.11.0'
+    dependencies:
+      zod: 3.22.2
 
   /zod-to-json-schema@3.21.4(zod@3.22.2):
     resolution: {integrity: sha512-fjUZh4nQ1s6HMccgIeE0VP4QG/YRGPmyjO9sAh890aQKPEk3nqbfUXhMFaC+Dr5KvYBm8BCyvfpZf2jY9aGSsw==}


### PR DESCRIPTION
This adds support for strongly-typed
form data using the `zod-form-data`
schema that are now supported alongside
regular Zod schemas.

Pages router router routes now support
validating and strongly typing form data
requests that have the `application/x-www-form-urlencoded`,
whereas app router routes also support strongly typed
`multipart/form-data` requests using the `req.formData()`
method from the NextRequest object.

Because RPC routes share the common `rpcOperation`
method for both pages and app router, strongly typed form
data is for now only supported with the `application/x-www-form-urlencoded`
content type.