### PR TITLE
fix pages router not generating due to hardcoded path

### DIFF
--- a/packages/next-rest-framework/src/cli/utils.ts
+++ b/packages/next-rest-framework/src/cli/utils.ts
@@ -161,7 +161,7 @@ export const findConfig = async ({ configPath }: { configPath?: string }) => {
             const filePathToRoute = join(
               process.cwd(),
               NEXT_REST_FRAMEWORK_TEMP_FOLDER_NAME,
-              'pages/api',
+              path,
               route
             );
 


### PR DESCRIPTION
hi,
noticed an issue with the pages router when using the `/src/pages/api` path due to this hardcoded path within the `findConfig` function. 
<img width="704" alt="image" src="https://github.com/blomqma/next-rest-framework/assets/39099608/3a2dd325-ebee-49c1-b621-4fc842888fa4">

The examples would also not run for me, after the change all was good 👍 
did some debugging and traced it back to this hardcoded path:
<img width="1440" alt="image" src="https://github.com/blomqma/next-rest-framework/assets/39099608/a6a2b7d6-f770-432a-a4df-714a6f79ad89">
