### PR TITLE
Fix async middleware typings

### DIFF
--- a/apps/example/src/app/page.tsx
+++ b/apps/example/src/app/page.tsx
@@ -58,7 +58,7 @@ export default function Page() {
             </a>
           </li>
           <li>
-            <a className="link link-primary" href="/api/v2">
+            <a className="link link-primary" href="/api/v1">
               SwaggerUI
             </a>
           </li>

--- a/packages/next-rest-framework/src/index.ts
+++ b/packages/next-rest-framework/src/index.ts
@@ -2,13 +2,16 @@ export {
   docsApiRoute,
   apiRoute,
   apiRouteOperation,
-  rpcApiRoute
+  rpcApiRoute,
+  type TypedNextApiRequest,
+  type TypedNextApiResponse
 } from './pages-router';
 export {
   docsRoute,
   route,
   routeOperation,
   rpcRoute,
+  type TypedNextRequest,
   TypedNextResponse
 } from './app-router';
 export { rpcOperation } from './shared';

--- a/packages/next-rest-framework/src/pages-router/api-route-operation.ts
+++ b/packages/next-rest-framework/src/pages-router/api-route-operation.ts
@@ -44,7 +44,7 @@ export type TypedNextApiRequest<
   }
 >;
 
-type TypedNextApiResponse<Body, Status, ContentType> = Modify<
+export type TypedNextApiResponse<Body, Status, ContentType> = Modify<
   NextApiResponse<Body>,
   {
     status: (status: Status) => TypedNextApiResponse<Body, Status, ContentType>;

--- a/packages/next-rest-framework/src/types.ts
+++ b/packages/next-rest-framework/src/types.ts
@@ -179,21 +179,24 @@ export type FormDataContentType =
   | 'application/x-www-form-urlencoded'
   | 'multipart/form-data';
 
-export type TypedFormData<T> = Modify<
-  FormData,
-  {
-    append: <K extends keyof T>(name: K, value: T[K] | Blob) => void;
-    delete: <K extends keyof T>(name: K) => void;
-    get: <K extends keyof T>(name: K) => T[K];
-    getAll: <K extends keyof T>(name: K) => Array<T[K]>;
-    has: <K extends keyof T>(name: K) => boolean;
-    set: <K extends keyof T>(name: K, value: T[K] | Blob) => void;
-    forEach: <K extends keyof T>(
-      callbackfn: (value: T[K], key: T, parent: TypedFormData<T>) => void,
-      thisArg?: any
-    ) => void;
-  }
->;
+export interface TypedFormData<T> extends FormData {
+  append: <K extends keyof T>(name: K, value: Blob | string) => void;
+  delete: <K extends keyof T & string>(name: K) => void;
+  get: <K extends keyof T & string>(name: K) => T[K] & FormDataEntryValue;
+  getAll: <K extends keyof T & string>(
+    name: K
+  ) => Array<T[K]> & FormDataEntryValue[];
+  has: <K extends keyof T & string>(name: K) => boolean;
+  set: <K extends keyof T>(name: K, value: Blob | string) => void;
+  forEach: <K extends keyof T & string>(
+    callbackfn: (
+      value: T[K] & FormDataEntryValue,
+      key: K,
+      parent: TypedFormData<T>
+    ) => void,
+    thisArg?: any
+  ) => void;
+}
 
 interface FormDataLikeInput {
   [Symbol.iterator]: () => IterableIterator<[string, FormDataEntryValue]>;

--- a/packages/next-rest-framework/tests/app-router/route.test.ts
+++ b/packages/next-rest-framework/tests/app-router/route.test.ts
@@ -2,7 +2,6 @@ import { z } from 'zod';
 import { TypedNextResponse, route, routeOperation } from '../../src/app-router';
 import { DEFAULT_ERRORS, ValidMethod } from '../../src/constants';
 import { createMockRouteRequest } from '../utils';
-import { NextResponse } from 'next/server';
 import { validateSchema } from '../../src/shared';
 import { zfd } from 'zod-form-data';
 
@@ -25,7 +24,7 @@ describe('route', () => {
               body: z.array(z.string())
             }
           ])
-          .handler(() => NextResponse.json(data));
+          .handler(() => TypedNextResponse.json(data));
 
       const res = await route({
         testGet: getOperation('GET'),
@@ -353,7 +352,7 @@ describe('route', () => {
         ])
         .handler(async (req) => {
           const { foo } = await req.json();
-          return NextResponse.json({ foo });
+          return TypedNextResponse.json({ foo });
         })
     }).POST(req, context);
 
@@ -542,7 +541,7 @@ describe('route', () => {
     const res = await route({
       test: routeOperation({ method: 'GET' })
         .middleware(() => {
-          return NextResponse.json({ foo: 'bar' }, { status: 200 });
+          return TypedNextResponse.json({ foo: 'bar' }, { status: 200 });
         })
         .handler(() => {
           console.log('foo');
@@ -591,7 +590,7 @@ describe('route', () => {
           console.log({ options: true, ...options });
           console.log({ 'x-foo': req.headers.get('x-foo') });
           console.log({ 'x-bar': req.headers.get('x-bar') });
-          return NextResponse.json(options);
+          return TypedNextResponse.json(options);
         })
     }).POST(req, context);
 
@@ -656,7 +655,7 @@ describe('route', () => {
         })
         .handler((_req, _ctx, options) => {
           console.log('handler');
-          return NextResponse.json(options);
+          return TypedNextResponse.json(options);
         })
     }).GET(req, context);
 


### PR DESCRIPTION
This fixes the TS error when using an async
middleware by fixing the return types of the
middleware function. This also exports the typings
of `TypedNextRerquest`, `TypedNextApiRequest` and
`TypedNextApiResponse` so that they can be used for
custom abstractions.