### PR TITLE
Fix dynamic server usage in app router docs route

### DIFF
--- a/docs/docs/getting-started.md
+++ b/docs/docs/getting-started.md
@@ -159,12 +159,6 @@ export const { GET, POST } = route({
 
 The `TypedNextResponse` ensures that the response status codes and content-type headers are type-checked against the defined outputs. You can still use the regular `NextResponse` if you prefer to have less type-safety.
 
-When using the default `nodejs` runtime with app router routes (`docsRoute` or `route`), you may encounter the [Dynamic server usage](https://nextjs.org/docs/messages/dynamic-server-error) Next.js error when running `next build`. In that case you should force the route to be dynamically rendered with the [dynamic](https://nextjs.org/docs/app/api-reference/file-conventions/route-segment-config#dynamic) option:
-
-```typescript
-export const dynamic = 'force-dynamic';
-```
-
 ##### [Pages router API route](#pages-router-api-route):
 
 ```typescript

--- a/packages/next-rest-framework/README.md
+++ b/packages/next-rest-framework/README.md
@@ -251,12 +251,6 @@ export const { GET, POST } = route({
 
 The `TypedNextResponse` ensures that the response status codes and content-type headers are type-checked against the defined outputs. You can still use the regular `NextResponse` if you prefer to have less type-safety.
 
-When using the default `nodejs` runtime with app router routes (`docsRoute` or `route`), you may encounter the [Dynamic server usage](https://nextjs.org/docs/messages/dynamic-server-error) Next.js error when running `next build`. In that case you should force the route to be dynamically rendered with the [dynamic](https://nextjs.org/docs/app/api-reference/file-conventions/route-segment-config#dynamic) option:
-
-```typescript
-export const dynamic = 'force-dynamic';
-```
-
 ##### [Pages router API route](#pages-router-api-route):
 
 ```typescript

--- a/packages/next-rest-framework/src/app-router/docs-route.ts
+++ b/packages/next-rest-framework/src/app-router/docs-route.ts
@@ -10,9 +10,12 @@ import {
 export const docsRoute = (_config?: NextRestFrameworkConfig) => {
   const config = getConfig(_config);
 
-  const handler = async (req: NextRequest, _context: { params: BaseQuery }) => {
+  const handler = async (
+    _req: NextRequest,
+    _context: { params: BaseQuery }
+  ) => {
     try {
-      const host = req.headers.get('host') ?? '';
+      const host = _req.clone().headers.get('host') ?? '';
       const html = getHtmlForDocs({ config, host });
 
       return new NextResponse(html, {


### PR DESCRIPTION
Currently in the app router docs route we read the request headers directly from the original request object. This is problematic because it leads to a dynamic server usage error unless the docs endpoint is explicitly set to `force-dynamic` caching strategy. By reading the headers from a cloned request object the docs endpoint can be used with the default caching strategy, fixing this issue.