### PR TITLE
Patch page body type

### DIFF
--- a/packages/next-rest-framework/src/pages-router/api-route-operation.ts
+++ b/packages/next-rest-framework/src/pages-router/api-route-operation.ts
@@ -38,7 +38,7 @@ export type TypedNextApiRequest<
       ? never
       : ContentType extends FormDataContentType
       ? TypedFormData<Body>
-      : never;
+      : Body;
     query: QueryAndParams;
     method: ValidMethod;
   }


### PR DESCRIPTION
Body for the page routes is always `never` unless you're using a form.

I believe original intention was only to be `never` when the method is GET.